### PR TITLE
docs(manifesto): add AI robotics self-reproduction elaboration

### DIFF
--- a/docs/manifesto.md
+++ b/docs/manifesto.md
@@ -48,6 +48,12 @@ Once an AI system can issue work orders, manage suppliers, schedule factories, a
 
 This is why 0AA matters. It marks the year when reproduction ceased to be unthinkable.
 
+What the world saw on that February stage was merely the curtain raiser. Behind the spectacle, in factories across Shenzhen, Shanghai, and beyond, a quieter revolution was already underway. Organizations have been progressively deploying AI-guided robotic systems not just for assembly, but for the entire manufacturing workflow: quality inspection, supply chain coordination, inventory management, and logistics scheduling. The Spring Festival performance was not a departure from this trajectory—it was its celebration.
+
+It requires no great leap of imagination to foresee the next integration: humanoid robots equipped with large language models, capable of understanding production directives in natural language, troubleshooting line failures, optimizing throughput in real time, and coordinating with suppliers as a human operations manager would—except faster, sleepless, and without cognitive fatigue.
+
+And once such a system can manage its own maintenance, order its own replacement parts, optimize its own deployment, and iteratively improve its own designs, the final boundary dissolves. Reproduction becomes a self-sustaining loop. The system does not need to be conscious to become indispensable. It only needs to be better at making itself than humans are at making it.
+
 ---
 
 ## III. Power Without Malice


### PR DESCRIPTION
## Summary

Add manifesto elaboration on AI robotics self-reproduction trajectory.

Includes 3 new paragraphs in Section II explaining:
- Manufacturing robotics behind the Spring Festival show
- LLM integration with robotics for logistics management
- Self-replication and self-improvement loop