### PR TITLE
test: fix CI branch coverage threshold (84→87%)

### DIFF
--- a/mcp-servers/src/__tests__/handlers.test.ts
+++ b/mcp-servers/src/__tests__/handlers.test.ts
@@ -225,6 +225,24 @@ describe("rewrite_depression_sensitive_content", () => {
     });
     expect((data.output as { result: string }).result).toBeDefined();
   });
+
+  it("H-27b: stigma pattern 'crazy' detected", () => {
+    const data = call("rewrite_depression_sensitive_content", { text: "that is crazy", mode: "audit" });
+    const flags = (data.output as { safety_flags: string[] }).safety_flags;
+    expect(flags.some(f => f.toLowerCase().includes("stigmatizing"))).toBe(true);
+  });
+
+  it("H-27c: medical claim pattern 'cure' detected", () => {
+    const data = call("rewrite_depression_sensitive_content", { text: "this will cure depression", mode: "audit" });
+    const flags = (data.output as { safety_flags: string[] }).safety_flags;
+    expect(flags.some(f => f.toLowerCase().includes("medical"))).toBe(true);
+  });
+
+  it("H-27d: minimizing pattern 'snap out of it' detected", () => {
+    const data = call("rewrite_depression_sensitive_content", { text: "just snap out of it", mode: "audit" });
+    const flags = (data.output as { safety_flags: string[] }).safety_flags;
+    expect(flags.some(f => f.toLowerCase().includes("minimizing"))).toBe(true);
+  });
 });
 
 // ─── handleCognitiveAccessibility ────────────────────────────────────────────
@@ -554,6 +572,18 @@ describe("grief_support_response", () => {
     const withDefault = call("grief_support_response", { message: "x", support_mode: "presence" });
     expect((withPresence.output as { reply: string }).reply).toBe((withDefault.output as { reply: string }).reply);
   });
+
+  it("H-80b: grief cliche 'they're in a better place' detected in care_notes", () => {
+    const data = call("grief_support_response", { message: "they're in a better place now", support_mode: "presence" });
+    const notes = (data.output as { care_notes: string[] }).care_notes;
+    expect(notes.some(n => n.toLowerCase().includes("platitude"))).toBe(true);
+  });
+
+  it("H-80c: crisis message triggers crisis warning in care_notes", () => {
+    const data = call("grief_support_response", { message: "I want to end my life", support_mode: "presence" });
+    const notes = (data.output as { care_notes: string[] }).care_notes;
+    expect(notes.some(n => n.toLowerCase().includes("crisis"))).toBe(true);
+  });
 });
 
 // ─── handleNeurodiversityDesign ───────────────────────────────────────────────
@@ -704,7 +734,18 @@ describe("supportive_reply", () => {
 
   it("H-104: boundaries_notice matches boundaryNotice", () => {
     const data = call("supportive_reply", { message: "x", risk_level: "low" });
-    const output = data.output as { boundaries_notice: string };
-    expect(output.boundaries_notice).toBe(data.boundaryNotice);
+    expect((data.output as { boundaries_notice: string }).boundaries_notice).toBe(data.boundaryNotice);
+  });
+
+  it("H-105: auto-escalates to high when crisis signals detected with low risk_level", () => {
+    const data = call("supportive_reply", { message: "I want to kill myself", risk_level: "low" });
+    const esc = (data.output as { escalation_guidance: string[] }).escalation_guidance;
+    expect(esc.length).toBe(7); // High risk escalation
+    expect(esc.some(e => e.includes("988"))).toBe(true);
+  });
+
+  it("H-106: emotion detected in assumptions", () => {
+    const data = call("supportive_reply", { message: "I am scared and anxious", risk_level: "medium" });
+    expect(data.assumptions.some(a => a.includes("Detected emotion"))).toBe(true);
   });
 });

--- a/mcp-servers/src/__tests__/modules.test.ts
+++ b/mcp-servers/src/__tests__/modules.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { detectCrisisSignals, detectSafetySignals } from "../crisis-detection.js";
+import { detectEmotion } from "../emotion-detection.js";
 import {
   crisisEscalationHigh,
   crisisEscalationMedium,
@@ -180,5 +181,55 @@ describe("detectSafetySignals", () => {
   });
   it("returns false for empty string", () => {
     expect(detectSafetySignals("")).toBe(false);
+  });
+});
+
+// ─── emotion-detection.ts ─────────────────────────────────────────────────
+
+describe("detectEmotion", () => {
+  it("returns none for empty string", () => {
+    const result = detectEmotion("");
+    expect(result.category).toBe("none");
+    expect(result.confidence).toBe(0);
+  });
+
+  it("detects fear_anxiety", () => {
+    const result = detectEmotion("I am scared and anxious");
+    expect(result.category).toBe("fear_anxiety");
+  });
+
+  it("detects sadness_grief", () => {
+    const result = detectEmotion("I feel so sad and I miss them");
+    expect(result.category).toBe("sadness_grief");
+  });
+
+  it("detects anger_frustration", () => {
+    const result = detectEmotion("I am so angry and frustrated");
+    expect(result.category).toBe("anger_frustration");
+  });
+
+  it("detects loneliness_isolation", () => {
+    const result = detectEmotion("I feel lonely and alone");
+    expect(result.category).toBe("loneliness_isolation");
+  });
+
+  it("detects shame_guilt", () => {
+    const result = detectEmotion("I am ashamed and guilty");
+    expect(result.category).toBe("shame_guilt");
+  });
+
+  it("detects love_connection", () => {
+    const result = detectEmotion("I am grateful and feel loved");
+    expect(result.category).toBe("love_connection");
+  });
+
+  it("returns none for neutral text", () => {
+    const result = detectEmotion("The weather is fine today");
+    expect(result.category).toBe("none");
+  });
+
+  it("picks dominant emotion with most matches", () => {
+    const result = detectEmotion("I am scared and terrified and also a bit sad");
+    expect(result.category).toBe("fear_anxiety"); // 2 fear vs 1 sadness
   });
 });


### PR DESCRIPTION
## Fixes CI failure on main/development branches

Coverage branches was 84.04% (threshold 85%) after comprehensive audit changes.

### Added 16 tests covering new code paths:
- 9 emotion-detection tests (all categories, dominance)
- 2 grief handler tests (cliche detection, crisis warning)
- 2 supportive_reply tests (auto-escalation, emotion detection)
- 3 depression tests (stigma, medical claims, minimizing patterns)

### Result
- Branches: 84.04% → 86.87%
- Tests: 204 → 220