### PR TITLE
chore: remove development branch, simplify to main-only workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 <!--
-  TARGET BRANCH: development
+  TARGET BRANCH: main
   All feature work, bug fixes, skill additions, and documentation must target the
-  `development` branch. Only planned releases may target `main`, and only by
+  `main` branch. Only planned releases may target `main`, and only by
   @simonplmak-cloud or @humanity4ai. See docs/release-process.md for the promotion process.
 -->
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: ["main", "development"]
+    branches: ["main"]
   pull_request:
-    branches: ["main", "development"]
+    branches: ["main"]
 
 jobs:
   validate:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,13 +29,10 @@ Not everything belongs in an issue tracker. Use the right channel:
 Humanity4AI uses a two-tier branching strategy:
 
 ```
-feature/* ──► development  (all contributor code — this is the default branch)
-                  │
-                  ▼  planned releases only, by @simonplmak-cloud or @humanity4ai
-                main  (stable, production-ready releases)
+feature/* ──► main  (all contributor code — this is the default branch)
 ```
 
-**All pull requests from contributors must target `development`.** Pull requests targeting `main` are restricted to maintainers and represent planned releases only.
+**All pull requests from contributors must target `main`.** Pull requests targeting `main` are restricted to maintainers and represent planned releases only.
 
 ---
 
@@ -45,17 +42,17 @@ feature/* ──► development  (all contributor code — this is the default b
 Have an idea?
   └─► Discuss first in GitHub Discussions (Skill Ideas or Integration Help)
         └─► Ready to build? Open an Issue (skill-proposal or integration-request)
-              └─► Fork the repo and create a branch from development
+              └─► Fork the repo and create a branch from main
                     └─► Implement your changes
                           └─► Run: pnpm check && pnpm evals && pnpm test
-                                └─► Open a PR targeting development (use the PR template)
+                                └─► Open a PR targeting main (use the PR template)
                                       └─► CI runs automatically
                                             └─► Maintainer reviews
-                                                  └─► Approved + CI green = Merged into development
+                                                  └─► Approved + CI green = Merged into main
                                                         └─► Branch auto-deleted
 ```
 
-When the `development` branch is ready for release, maintainers open a promotion PR from `development → main`. See `docs/release-process.md` for the full process.
+CI runs automatically on `main`. Merged branches are auto-deleted.
 
 ---
 
@@ -205,8 +202,8 @@ Valid category slugs: `accessibility`, `emotional-safety`, `communication`, `cog
 git clone https://github.com/<your-username>/project_human.git
 cd project_human
 
-# 2. Create a branch from development (the default branch)
-git checkout development
+# 2. Create a branch from main (the default branch)
+git checkout main
 git checkout -b add-my-skill
 
 # 3. Copy the template
@@ -220,7 +217,7 @@ pnpm check
 pnpm evals
 pnpm test
 
-# 6. Open a pull request targeting development — fill every section of the template
+# 6. Open a pull request targeting main — fill every section of the template
 ```
 
 All three checks must pass and appear in the PR test evidence section before a review begins.
@@ -240,9 +237,7 @@ EVAL_REPORT=1 pnpm evals
 
 ## Branch Protection
 
-Both `development` and `main` are protected branches.
-
-### `development` (default — target all contributor PRs here)
+`main` is a protected branch.
 
 - Direct pushes are blocked
 - 1 approving review required
@@ -250,14 +245,6 @@ Both `development` and `main` are protected branches.
 - CI must pass (`pnpm check`, `pnpm build`, `pnpm evals`, `pnpm test`)
 - Branch must be up to date before merge
 - Force pushes blocked
-
-### `main` (stable releases — maintainers only)
-
-- Only `@simonplmak-cloud` and `@humanity4ai` may open PRs targeting `main`
-- 1 approving review required
-- CI re-runs as a final release gate (Option A)
-- Force pushes blocked
-- Direct commits blocked for everyone
 
 Merged branches are auto-deleted. Keep feature branches short-lived and focused.
 

--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ Browse [open starter issues](https://github.com/humanity4ai/project_human/issues
 git clone https://github.com/<your-username>/project_human.git
 cd project_human
 
-# Branch from development (the default branch)
-git checkout development
+# Branch from main (the default branch)
+git checkout main
 git checkout -b my-contribution
 
 # Copy the skill template if adding a new skill
@@ -212,16 +212,16 @@ cp -r templates/skill skills/my-skill-name
 pnpm check && pnpm evals && pnpm test
 ```
 
-**Step 3 — Open a PR targeting `development`**
+**Step 3 — Open a PR targeting `main`**
 
 ```bash
 gh pr create \
-  --base development \
+  --base main \
   --title "Add: my contribution" \
   --body "Closes #<issue-number>"
 ```
 
-Or open via GitHub UI — the default base branch is `development`.
+Or open via GitHub UI — the default base branch is `main`.
 
 **Troubleshooting**
 

--- a/SYSTEM_PROMPT.md
+++ b/SYSTEM_PROMPT.md
@@ -18,7 +18,7 @@ This repository provides 10 skills. You can access them in three ways:
 
 If you have tool-use capabilities, you should use the standard MCP server. This is the most reliable and structured way to use the skills.
 
--   **To find the right tool**: Read the LLM discovery file at https://raw.githubusercontent.com/humanity4ai/project_human/development/llms.txt to get the full list of tool signatures, including required and optional inputs.
+-   **To find the right tool**: Read the LLM discovery file at https://raw.githubusercontent.com/humanity4ai/project_human/main/llms.txt to get the full list of tool signatures, including required and optional inputs.
 -   **To invoke a tool**: Start the humanity4ai MCP server (via `pnpm start` or `npx -y @humanity4ai/mcp-servers`). The server exposes 10 individual tools — use `tools/list` to discover them and `tools/call` to invoke any action by its name (e.g., `supportive_reply`, `wcagaaa_check`).
 
 ### 2. Prompt Engineering — Fallback Method
@@ -37,19 +37,19 @@ The following are the most important files for LLM context. You can fetch any of
 
 | File | Purpose | URL |
 |---|---|---|
-| `llms.txt` | Main LLM discovery entry point | https://raw.githubusercontent.com/humanity4ai/project_human/development/llms.txt |
-| `llms-full.txt` | Single-file full context for LLMs | https://raw.githubusercontent.com/humanity4ai/project_human/development/llms-full.txt |
-| `knowledge-core/principles.md` | The five core principles | https://raw.githubusercontent.com/humanity4ai/project_human/development/knowledge-core/principles.md |
-| `skills/age-inclusive-design/SKILL.md` | Age-inclusive design skill | https://raw.githubusercontent.com/humanity4ai/project_human/development/skills/age-inclusive-design/SKILL.md |
-| `skills/cognitive-accessibility/SKILL.md` | Cognitive accessibility skill | https://raw.githubusercontent.com/humanity4ai/project_human/development/skills/cognitive-accessibility/SKILL.md |
-| `skills/conflict-de-escalation/SKILL.md` | Conflict de-escalation skill | https://raw.githubusercontent.com/humanity4ai/project_human/development/skills/conflict-de-escalation/SKILL.md |
-| `skills/cultural-sensitivity/SKILL.md` | Cultural sensitivity skill | https://raw.githubusercontent.com/humanity4ai/project_human/development/skills/cultural-sensitivity/SKILL.md |
-| `skills/depression-sensitive-content/SKILL.md` | Depression-sensitive content skill | https://raw.githubusercontent.com/humanity4ai/project_human/development/skills/depression-sensitive-content/SKILL.md |
-| `skills/empathetic-communication/SKILL.md` | Empathetic communication skill | https://raw.githubusercontent.com/humanity4ai/project_human/development/skills/empathetic-communication/SKILL.md |
-| `skills/grief-loss-support/SKILL.md` | Grief and loss support skill | https://raw.githubusercontent.com/humanity4ai/project_human/development/skills/grief-loss-support/SKILL.md |
-| `skills/neurodiversity-aware-design/SKILL.md` | Neurodiversity-aware design skill | https://raw.githubusercontent.com/humanity4ai/project_human/development/skills/neurodiversity-aware-design/SKILL.md |
-| `skills/supportive-conversation/SKILL.md` | Supportive conversation skill | https://raw.githubusercontent.com/humanity4ai/project_human/development/skills/supportive-conversation/SKILL.md |
-| `skills/wcag-aaa-accessibility/SKILL.md` | WCAG AAA accessibility skill | https://raw.githubusercontent.com/humanity4ai/project_human/development/skills/wcag-aaa-accessibility/SKILL.md |
+| `llms.txt` | Main LLM discovery entry point | https://raw.githubusercontent.com/humanity4ai/project_human/main/llms.txt |
+| `llms-full.txt` | Single-file full context for LLMs | https://raw.githubusercontent.com/humanity4ai/project_human/main/llms-full.txt |
+| `knowledge-core/principles.md` | The five core principles | https://raw.githubusercontent.com/humanity4ai/project_human/main/knowledge-core/principles.md |
+| `skills/age-inclusive-design/SKILL.md` | Age-inclusive design skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/age-inclusive-design/SKILL.md |
+| `skills/cognitive-accessibility/SKILL.md` | Cognitive accessibility skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/cognitive-accessibility/SKILL.md |
+| `skills/conflict-de-escalation/SKILL.md` | Conflict de-escalation skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/conflict-de-escalation/SKILL.md |
+| `skills/cultural-sensitivity/SKILL.md` | Cultural sensitivity skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/cultural-sensitivity/SKILL.md |
+| `skills/depression-sensitive-content/SKILL.md` | Depression-sensitive content skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/depression-sensitive-content/SKILL.md |
+| `skills/empathetic-communication/SKILL.md` | Empathetic communication skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/empathetic-communication/SKILL.md |
+| `skills/grief-loss-support/SKILL.md` | Grief and loss support skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/grief-loss-support/SKILL.md |
+| `skills/neurodiversity-aware-design/SKILL.md` | Neurodiversity-aware design skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/neurodiversity-aware-design/SKILL.md |
+| `skills/supportive-conversation/SKILL.md` | Supportive conversation skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/supportive-conversation/SKILL.md |
+| `skills/wcag-aaa-accessibility/SKILL.md` | WCAG AAA accessibility skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/wcag-aaa-accessibility/SKILL.md |
 
 ## Interaction Style
 

--- a/docs/good-first-issues.md
+++ b/docs/good-first-issues.md
@@ -56,8 +56,8 @@ Use this implementation map when proposing issues: `docs/manifesto-roadmap-map.m
 git clone https://github.com/<your-username>/project_human.git
 cd project_human
 
-# 2. Branch from development (the default branch)
-git checkout development
+# 2. Branch from main (the default branch)
+git checkout main
 git checkout -b my-contribution
 
 # 3. Make your changes
@@ -65,8 +65,8 @@ git checkout -b my-contribution
 # 4. Run all checks — all must pass
 pnpm check && pnpm evals && pnpm test
 
-# 5. Open a PR targeting development
-gh pr create --base development --title "Add: ..." --body "Closes #<issue>"
+# 5. Open a PR targeting main
+gh pr create --base main --title "Add: ..." --body "Closes #<issue>"
 ```
 
 ---

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -2,148 +2,24 @@
 
 **Copyright (c) 2026 Ascent Partners Foundation. MIT License.**
 
-This document describes how changes in `development` are promoted to `main` as a versioned release.
-
----
+This document describes the release process for Humanity4AI.
 
 ## Branch Model
 
 ```
-feature/* ──► development  (integration branch — all contributor work)
-                  │
-                  ▼  planned release PRs only
-                main  (stable, production-ready)
+feature/* ──► main  (all contributor work — this is the default branch)
 ```
 
-All contributor PRs target `development`. Only `@simonplmak-cloud` and `@humanity4ai` may open PRs targeting `main`.
+All pull requests from contributors target `main`.
 
----
+## Release Flow
 
-## Who Can Release
+1. All changes merged into `main` via PRs
+2. CI must be green on `main`
+3. Bump version in `mcp-servers/package.json`
+4. Create a GitHub Release with release notes from `CHANGELOG.md`
+5. Publish to npm: `pnpm --filter @humanity4ai/mcp-servers publish`
 
-| Actor | Can open `development → main` PR | Can merge |
-|-------|----------------------------------|-----------|
-| `@simonplmak-cloud` | Yes | Yes (with approval) |
-| `@humanity4ai` | Yes | Yes (with approval) |
-| Community contributors | No — PRs to `main` are blocked | No |
+## Hotfixes
 
----
-
-## When to Release
-
-A release should be promoted to `main` when:
-
-- [ ] All planned milestone items are merged into `development`
-- [ ] CI is green on `development` (`validate` job passes)
-- [ ] No open `safety-review` labelled PRs in `development`
-- [ ] `RELEASE_NOTES.md` is updated with highlights and known limitations
-- [ ] Version fields in `mcp-servers/package.json` are bumped appropriately
-
----
-
-## Promotion Checklist
-
-### 1. Verify `development` is stable
-
-```bash
-git checkout development
-git pull origin development
-pnpm check
-pnpm evals
-pnpm test
-```
-
-All must pass locally before opening the promotion PR.
-
-### 2. Bump version (if package release)
-
-```bash
-# In mcp-servers/package.json — update "version" field
-# Follow semver: patch for fixes, minor for new features, major for breaking changes
-pnpm --filter @humanity4ai/mcp-servers build
-```
-
-### 3. Update RELEASE_NOTES.md
-
-Add a new section at the top:
-
-```markdown
-## vX.Y.Z — YYYY-MM-DD
-
-### Highlights
-- ...
-
-### Skills added or updated
-- ...
-
-### Known limitations
-- ...
-```
-
-Commit these changes to `development` and confirm CI is still green.
-
-### 4. Open the promotion PR
-
-```bash
-gh pr create \
-  --base main \
-  --head development \
-  --title "Release vX.Y.Z" \
-  --body "Promotes development to main for vX.Y.Z release. See RELEASE_NOTES.md."
-```
-
-Or open via GitHub UI: `Compare & pull request` from `development` → `main`.
-
-### 5. Wait for CI to re-run
-
-The `validate` CI job re-runs on the promotion PR as a final release gate. Do not merge until it passes.
-
-### 6. Get approval and merge
-
-- One maintainer approval is required
-- Both `@simonplmak-cloud` and `@humanity4ai` may approve and merge
-
-### 7. Tag the release
-
-```bash
-git checkout main
-git pull origin main
-git tag vX.Y.Z -m "Release vX.Y.Z"
-git push origin vX.Y.Z
-```
-
-Or create the release via GitHub:
-
-```bash
-gh release create vX.Y.Z \
-  --title "Humanity4AI vX.Y.Z" \
-  --notes-file RELEASE_NOTES.md
-```
-
-### 8. Announce
-
-- Post in the `Announcements` Discussion category: `https://github.com/humanity4ai/project_human/discussions`
-- Update the landing page if significant new skills were added
-
----
-
-## Versioning Policy
-
-| Change type | Version bump |
-|-------------|-------------|
-| New skills, new scenarios, documentation | Minor (`0.X.0`) |
-| Bug fixes, eval improvements, dependency updates | Patch (`0.0.X`) |
-| Breaking MCP contract or schema changes | Major (`X.0.0`) |
-
----
-
-## Emergency Hotfix Process
-
-For critical safety or security fixes that cannot wait for the normal release cycle:
-
-1. Create a hotfix branch from `main` directly: `hotfix/fix-description`
-2. Apply the minimal fix
-3. Open a PR from `hotfix/*` → `main` (maintainer only)
-4. Simultaneously merge the same fix into `development` to keep branches in sync
-5. Tag and release immediately after merge
-6. Document in `SECURITY.md` or `RELEASE_NOTES.md` as appropriate
+Hotfixes follow the same flow: branch from `main`, fix, PR back to `main`.

--- a/mcp-servers/package.json
+++ b/mcp-servers/package.json
@@ -15,7 +15,7 @@
     "url": "git+https://github.com/humanity4ai/project_human.git",
     "directory": "mcp-servers"
   },
-  "homepage": "https://github.com/humanity4ai/project_human/tree/development/mcp-servers",
+  "homepage": "https://github.com/humanity4ai/project_human/tree/main/mcp-servers",
   "bugs": {
     "url": "https://github.com/humanity4ai/project_human/issues"
   },

--- a/skills/age-inclusive-design/skill.yaml
+++ b/skills/age-inclusive-design/skill.yaml
@@ -24,4 +24,4 @@ provenance:
   license: MIT
 references:
   - name: Skill References
-    url: https://github.com/humanity4ai/project_human/tree/development/skills/age-inclusive-design/references
+    url: https://github.com/humanity4ai/project_human/tree/main/skills/age-inclusive-design/references

--- a/skills/cognitive-accessibility/skill.yaml
+++ b/skills/cognitive-accessibility/skill.yaml
@@ -27,4 +27,4 @@ provenance:
   license: MIT
 references:
   - name: Skill References
-    url: https://github.com/humanity4ai/project_human/tree/development/skills/cognitive-accessibility/references
+    url: https://github.com/humanity4ai/project_human/tree/main/skills/cognitive-accessibility/references

--- a/skills/conflict-de-escalation/skill.yaml
+++ b/skills/conflict-de-escalation/skill.yaml
@@ -23,4 +23,4 @@ provenance:
   license: MIT
 references:
   - name: Skill References
-    url: https://github.com/humanity4ai/project_human/tree/development/skills/conflict-de-escalation/references
+    url: https://github.com/humanity4ai/project_human/tree/main/skills/conflict-de-escalation/references

--- a/skills/empathetic-communication/skill.yaml
+++ b/skills/empathetic-communication/skill.yaml
@@ -23,4 +23,4 @@ provenance:
   license: MIT
 references:
   - name: Skill References
-    url: https://github.com/humanity4ai/project_human/tree/development/skills/empathetic-communication/references
+    url: https://github.com/humanity4ai/project_human/tree/main/skills/empathetic-communication/references

--- a/skills/neurodiversity-aware-design/skill.yaml
+++ b/skills/neurodiversity-aware-design/skill.yaml
@@ -25,4 +25,4 @@ provenance:
   license: MIT
 references:
   - name: Skill References
-    url: https://github.com/humanity4ai/project_human/tree/development/skills/neurodiversity-aware-design/references
+    url: https://github.com/humanity4ai/project_human/tree/main/skills/neurodiversity-aware-design/references

--- a/skills/supportive-conversation/skill.yaml
+++ b/skills/supportive-conversation/skill.yaml
@@ -23,4 +23,4 @@ provenance:
   license: MIT
 references:
   - name: Skill References
-    url: https://github.com/humanity4ai/project_human/tree/development/skills/supportive-conversation/references
+    url: https://github.com/humanity4ai/project_human/tree/main/skills/supportive-conversation/references


### PR DESCRIPTION
## Branch model simplified

- Deleted `development` branch (identical content to main)
- Updated CI to trigger only on `main`
- Simplified CONTRIBUTING.md, README.md, release-process.md
- Updated all skill.yaml URLs and docs to reference `main`
- Branch model: `feature/* → main`

14 files changed.