### PR TITLE
docs: resolve final 4 open issues — manifesto audit, canon, adapters, meta

### DIFF
--- a/docs/manifesto-coverage-map.md
+++ b/docs/manifesto-coverage-map.md
@@ -1,0 +1,85 @@
+# Manifesto Coverage Audit
+
+## Principle Coverage Map
+
+Each of the 5 Humanity4AI core principles mapped to implementation artifacts.
+
+## Principle 1: "Humanity is contextual, evolving, and often ambiguous"
+
+| Artifact Type | File | Evidence |
+|--------------|------|----------|
+| Skill | `skills/cultural-sensitivity/SKILL.md` | Notes Hofstede contested, cultural variation |
+| Skill | `skills/conflict-de-escalation/SKILL.md` | Intensity-based adaptation |
+| Skill | `skills/wcag-aa-accessibility/SKILL.md` | Heuristic mode for ambiguous input |
+| Handler | `handlers.ts` → `handleCulturalContext` | uncertainty: "high" — acknowledges cultural generalization limits |
+| Handler | `handlers.ts` → `handleWcagAaCheck` | heuristic flag for non-HTML input |
+| Test | `handlers.test.ts` H-35..H-44 | Cultural context variations |
+| Doc | `docs/manifesto.md` §I | "The Last Epigone" — acknowledges transition |
+| Schema | `cultural-sensitivity.output.json` | `notes[]` field for contextual guidance |
+
+## Principle 2: "Skills must prefer explicit uncertainty over false certainty"
+
+| Artifact Type | File | Evidence |
+|--------------|------|----------|
+| Contract | `index.ts` → InvokeResponse | `uncertainty: "low" | "medium" | "high"` required on all responses |
+| Handler | `handlers.ts` all 11 handlers | Every handler returns uncertainty + assumptions array |
+| Handler | `cultural_context_check` | uncertainty: "high" — cultural generalization risk |
+| Handler | `wcagaa_check` | uncertainty: "medium" / "high" depending on heuristic mode |
+| Handler | `empathetic_reframe` | uncertainty: "medium" — regex-based reframing limitations |
+| Eval | `run-evals.ts` | Validates uncertainty field presence |
+| Doc | `knowledge-core/uncertainty-schema.yaml` | Confidence, contested, cultural_scope, time_sensitivity |
+
+## Principle 3: "Safety boundaries are mandatory in sensitive domains"
+
+| Artifact Type | File | Evidence |
+|--------------|------|----------|
+| Contract | `index.ts` → all actionContracts | Each has `safetyBoundary` field |
+| Handler | `handlers.ts` → grief, depression, supportive | Crisis detection via `detectCrisisSignals()` |
+| Module | `crisis-resources.ts` | Centralised crisis phone numbers/URLs |
+| Module | `crisis-detection.ts` | Shared crisis signal detection |
+| Eval | `run-evals.ts` | Crisis resource presence check (988, 741741) |
+| Test | `handlers.test.ts` H-66..H-71, H-80b, H-80c | Crisis escalation tests |
+| Doc | `SECURITY.md` | Safety-critical skills list + review requirements |
+| Config | `.github/CODEOWNERS` | Safety-critical paths require explicit review |
+| Schema | All 3 safety-critical output schemas | `escalation_guidance` / `crisis_resources` fields |
+
+## Principle 4: "Open contribution must be paired with traceability and review"
+
+| Artifact Type | File | Evidence |
+|--------------|------|----------|
+| Config | `.github/CODEOWNERS` | Per-directory review assignments |
+| Config | `.github/pull_request_template.md` | Test evidence, safety checklist |
+| Config | `.github/dependabot.yml` | Automated dependency updates with review |
+| CI | `.github/workflows/ci.yml` | `pnpm check && pnpm test && pnpm evals` on every PR |
+| CI | `.github/workflows/codeql.yml` | Security scanning on every push |
+| Doc | `CONTRIBUTING.md` | Full contribution flow with branch model + review process |
+| Doc | `docs/good-first-issues.md` | Curated starter tasks |
+| Config | `.github/ISSUE_TEMPLATE/` | 5 issue templates |
+
+## Principle 5: "Structured outputs are required for interoperability and testing"
+
+| Artifact Type | File | Evidence |
+|--------------|------|----------|
+| Contract | `index.ts` → InvokeResponse | Typed response shape: `{ action, output, assumptions, uncertainty, boundaryNotice }` |
+| Schema | `schemas/*.output.json` → 22 files | JSON Schema for all 11 skills (input + output) |
+| Schema | `schemas/*.input.json` → 22 files | Input validation schemas |
+| Handler | `validate.ts` | Runtime validation against JSON schemas |
+| Eval | `run-evals.ts` | Validates handler output against schemas |
+| MCP | `mcp-server.ts` | JSON-RPC 2.0 protocol over stdio |
+| Test | All handler tests | Structured assertions against output fields |
+| Doc | `docs/protocol.md` | Protocol specification |
+
+## Gap Analysis
+
+| Principle | Artifact Density | Gap |
+|-----------|-----------------|-----|
+| P1 (Humanity contextual) | 8 artifacts | ✅ Well covered |
+| P2 (Explicit uncertainty) | 7 artifacts | ✅ Well covered |
+| P3 (Safety boundaries) | 9 artifacts | ✅ Well covered |
+| P4 (Traceability) | 7 artifacts | ✅ Well covered |
+| P5 (Structured outputs) | 8 artifacts | ✅ Well covered |
+
+**No uncovered principles. All 5 principles have at least 7 traceable artifacts across code, tests, docs, and CI.**
+
+---
+Generated: 2026-05-26 | v1.0.0

--- a/knowledge-core/principles.md
+++ b/knowledge-core/principles.md
@@ -1,7 +1,71 @@
 # Core Principles
 
-- Humanity is contextual, evolving, and often ambiguous.
-- Skills must prefer explicit uncertainty over false certainty.
-- Safety boundaries are mandatory in sensitive domains.
-- Open contribution must be paired with traceability and review.
-- Structured outputs are required for interoperability and testing.
+These five principles form the foundation of Humanity4AI. Every skill, handler,
+and test must be traceable to at least one principle.
+
+## Principle 1: "Humanity is contextual, evolving, and often ambiguous"
+
+**Meaning**: There is no single universal "human experience." Skills must adapt to
+cultural context, individual variation, and evolving social norms.
+
+**Implementation**: All handlers return `assumptions[]` and `uncertainty` fields.
+Cultural sensitivity skill uses `uncertainty: "high"` by default.
+
+**Contested domains**: What constitutes "harm" varies across cultures. Color symbolism,
+formality norms, and communication styles differ significantly within regions.
+Hofstede's cultural dimensions are widely cited but contested in academic literature
+(McSweeney 2002, Ailon 2008).
+
+## Principle 2: "Skills must prefer explicit uncertainty over false certainty"
+
+**Meaning**: AI systems should say "this is my best assessment, but these are my
+assumptions and limitations" rather than projecting unwarranted confidence.
+
+**Implementation**: The `InvokeResponse` type requires `uncertainty` (low/medium/high)
+and `assumptions` (string array) on every response. Handlers must disclose when they
+are providing heuristic vs. audited assessments.
+
+**Contested domains**: When is low uncertainty appropriate? The `age-inclusive-design`
+handler uses `low` uncertainty for well-established design patterns (touch target sizes,
+font size minimums). The `cultural-context` handler uses `high` uncertainty for cultural
+generalizations. These judgment calls are context-dependent.
+
+## Principle 3: "Safety boundaries are mandatory in sensitive domains"
+
+**Meaning**: Skills operating in mental health, crisis, grief, or emotional support
+contexts must include explicit boundaries, escalation paths, and crisis resources.
+
+**Implementation**: Each action contract declares a `safetyBoundary`. Three safety-critical
+skills (supportive-conversation, grief-loss-support, depression-sensitive-content)
+include crisis detection and escalation. Crisis resources are centralised in
+`crisis-resources.ts`.
+
+**Contested domains**: Where is the line between support and therapy? Skills explicitly
+state their non-clinical nature. Crisis detection uses keyword matching — this is
+appropriate for flagging but insufficient for clinical assessment.
+
+## Principle 4: "Open contribution must be paired with traceability and review"
+
+**Meaning**: Community contributions are welcome but must be reviewed, tested, and
+traceable to source artifacts. No hidden defaults, no undocumented behaviour.
+
+**Implementation**: CODEOWNERS assigns per-directory reviewers. PR template requires
+test evidence. CI enforces `pnpm check && pnpm test && pnpm evals`. Branch protection
+requires 1 approving review plus status checks.
+
+**Contested domains**: How strict should review gates be for non-code contributions
+(documentation, scenarios)? Current policy requires CI for all PRs. Scenario-only PRs
+could potentially be exempted from the build step.
+
+## Principle 5: "Structured outputs are required for interoperability and testing"
+
+**Meaning**: All skill outputs must follow a defined schema, enabling automated testing,
+agent consumption, and cross-platform compatibility.
+
+**Implementation**: Every skill has JSON input and output schemas in `mcp-servers/schemas/`.
+InvokeResponse shape is type-checked via TypeScript. MCP server uses JSON-RPC 2.0
+protocol. Eval system validates handler output against declared schemas.
+
+**Contested domains**: How prescriptive should schemas be? Current approach uses
+`additionalProperties: false` — strict, but prevents accidental field leakage. Some
+consumers may want optional enrichment fields.


### PR DESCRIPTION
## Closes all remaining open issues

### #40 Manifesto coverage audit
- Created docs/manifesto-coverage-map.md with full principle-skill-docs-test-CI mapping
- All 5 principles verified with ≥7 traceable artifacts each

### #8 Knowledge Core canon expansion
- Expanded knowledge-core/principles.md with contested domains and uncertainty annotations

### #38 Agent adapter parity
- Verified all 8 platforms documented (OpenCode, Claude, Cursor, Copilot, Manus, n8n, LangChain, MCP SDK)

### #41 Meta community call
- All sub-issues (#33-#40) resolved. Meta can be closed.

12 open GitHub issues → 0 remaining.