### PR TITLE
fix: add publish-branch main to package.json

### DIFF
--- a/mcp-servers/package.json
+++ b/mcp-servers/package.json
@@ -34,6 +34,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "publish-branch": "main",
   "bin": {
     "humanity4ai-mcp": "./dist/bin.js"
   },


### PR DESCRIPTION
Prevents branch warning on npm publish.