### PR TITLE
fix: V-18 test — accessibility schema input format

### DIFF
--- a/mcp-servers/src/__tests__/validate.test.ts
+++ b/mcp-servers/src/__tests__/validate.test.ts
@@ -183,7 +183,7 @@ describe("validateInput — required field checks", () => {
   it("V-18: field with undefined value in input is skipped (no error)", () => {
     const result = validateInput(
       "schemas/accessibility.input.json",
-      { target: "https://example.com", level: "AAA", context: undefined as unknown as string }
+      { mode: "session", level: "AA", locale: undefined as unknown as string }
     );
     expect(result.valid).toBe(true);
   });


### PR DESCRIPTION
Fixes V-18 test that still used old wcag format with target field.