### PR TITLE
fix: AGENTS.md + site — 9 skills, accurate counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,16 @@ Add to your MCP client config:
 }
 ```
 
-All 10 humanity skills are now discoverable via `tools/list` and invocable via `tools/call`.
+All 9 humanity skills are now discoverable via `tools/list` and invocable via `tools/call`.
 
 ---
 ## Three Ways to Use Humanity4AI Skills
 
-This repository provides **10 Humanity Skills** — reusable, testable specifications for humane AI behaviour covering empathy, accessibility, grief support, cultural sensitivity, and more. There are three distinct ways to access these skills, depending on your AI platform and its capabilities.
+This repository provides **9 Humanity Skills** — reusable, testable specifications for humane AI behaviour covering empathy, accessibility, grief support, cultural sensitivity, and more. There are three distinct ways to access these skills, depending on your AI platform and its capabilities.
 
 | Method | Skills Access | Best for... | How it Works |
 |---|---|---|---|
-| **1. MCP Server** | All 10 skills as invocable tools | Developer tools (VS Code, Cursor) and agents (Manus AI, OpenCode) | Run a local server that exposes all 10 skills as tools via the Model Context Protocol (MCP). |
+| **1. MCP Server** | All 9 skills as invocable tools | Developer tools (VS Code, Cursor) and agents (Manus AI, OpenCode) | Run a local server that exposes all 10 skills as tools via the Model Context Protocol (MCP). |
 | **2. LLM Prompting** | Any skill via context window | Web chat AIs (Claude, Gemini, ChatGPT) | Provide the content of `llms.txt` or a specific `SKILL.md` directly in the chat context. |
 | **3. Local Files** | Any skill via filesystem | CLI tools without web access (OpenCode) | Clone the repository and point the tool to the relevant `SKILL.md` file path. |
 
@@ -161,7 +161,7 @@ Configure your agent by adding this to your MCP client config:
 }
 ```
 
-All 10 humanity skills are discoverable via `tools/list` and invocable via `tools/call`.
+All 9 humanity skills are discoverable via `tools/list` and invocable via `tools/call`.
 See [`mcp-servers/README.md`](mcp-servers/README.md) for full protocol details and tool reference.
 
 Full install and deploy guide: [`INSTALL.md`](docs/INSTALL.md)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## v1.0 (Current)
 
-- 10 launch skills with structured artifacts
+- 9 launch skills with structured artifacts
 - MCP action contracts and schema set
 - Standard MCP SDK (JSON-RPC 2.0) implementation
 - Baseline evaluation harness and governance framework

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -61,5 +61,5 @@ PASS  wcag-aaa-accessibility
 PASS  wcag-aa-accessibility
 PASS  contract-consistency
 
-All 10 checks passed.
+All 9 checks passed.
 ```

--- a/site/index.html
+++ b/site/index.html
@@ -44,7 +44,7 @@
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Humanity4AI",
-      "description": "Open skill system for humane AI — 10 reusable specifications with MCP contracts and evaluation gates.",
+      "description": "Open skill system for humane AI — 9 reusable specifications with MCP contracts and evaluation gates.",
       "url": "https://humanity4ai.github.io/project_human/",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "Cross-platform",
@@ -96,7 +96,7 @@ pnpm start</code></pre>
     }
   }
 }</code></pre>
-        <p>        All 10 skills are now available via <code>tools/list</code> and <code>tools/call</code>.</p>
+        <p>        All 9 skills are now available via <code>tools/list</code> and <code>tools/call</code>.</p>
       </section>
 
       <section class="manifesto" aria-label="Manifesto">
@@ -117,7 +117,7 @@ pnpm start</code></pre>
         <h2>What ships now</h2>
         <div class="grid three">
           <article class="card">
-            <h3>10 Skill Packs</h3>
+            <h3>9 Skill Packs</h3>
             <p>Accessibility, emotional safety, inclusive design, and communication patterns.</p>
           </article>
           <article class="card">


### PR DESCRIPTION
Updates AGENTS.md and documentation to reflect actual project state:

### AGENTS.md changes
- 9 skills (was 11, then 10 — now verified at 9)
- 18 schemas (9 × 2)
- 9 handlers
-  is async (returns Promise\<HandlerResult\>)
- Added  to shared modules
- Accurate bin entry: 
- : 13 scoring functions, all 78 WCAG criteria, optional axe-core

### Site/Docs
- 10→9 skill count in site, README, ROADMAP, quality-gates