### PR TITLE
Fix double main() invocation crashing bin entry

### DIFF
--- a/mcp-servers/dist/bin.d.ts
+++ b/mcp-servers/dist/bin.d.ts
@@ -1,3 +1,14 @@
 #!/usr/bin/env node
-export {};
+/**
+ * Humanity4AI MCP Server — npx entry point
+ *
+ * This file is the binary entry point for the npm package.
+ * It starts the standard MCP SDK server (JSON-RPC 2.0 over stdio).
+ *
+ * Usage:
+ *   npx -y @humanity4ai/mcp-servers
+ *
+ * Copyright (c) 2026 Ascent Partners Foundation. MIT License.
+ */
+import "./mcp-server.js";
 //# sourceMappingURL=bin.d.ts.map

--- a/mcp-servers/dist/bin.d.ts.map
+++ b/mcp-servers/dist/bin.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"bin.d.ts","sourceRoot":"","sources":["../src/bin.ts"],"names":[],"mappings":""}
+{"version":3,"file":"bin.d.ts","sourceRoot":"","sources":["../src/bin.ts"],"names":[],"mappings":";AACA;;;;;;;;;;GAUG;AACH,OAAO,iBAAiB,CAAC"}

--- a/mcp-servers/dist/bin.js
+++ b/mcp-servers/dist/bin.js
@@ -10,9 +10,5 @@
  *
  * Copyright (c) 2026 Ascent Partners Foundation. MIT License.
  */
-import { main } from "./mcp-server.js";
-main().catch((err) => {
-    process.stderr.write(`Fatal error: ${String(err)}\n`);
-    process.exit(1);
-});
+import "./mcp-server.js";
 //# sourceMappingURL=bin.js.map

--- a/mcp-servers/dist/bin.js.map
+++ b/mcp-servers/dist/bin.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"bin.js","sourceRoot":"","sources":["../src/bin.ts"],"names":[],"mappings":";AACA;;;;;;;;;;GAUG;AACH,OAAO,EAAE,IAAI,EAAE,MAAM,iBAAiB,CAAC;AAEvC,IAAI,EAAE,CAAC,KAAK,CAAC,CAAC,GAAY,EAAE,EAAE;IAC5B,OAAO,CAAC,MAAM,CAAC,KAAK,CAAC,gBAAgB,MAAM,CAAC,GAAG,CAAC,IAAI,CAAC,CAAC;IACtD,OAAO,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;AAClB,CAAC,CAAC,CAAC"}
+{"version":3,"file":"bin.js","sourceRoot":"","sources":["../src/bin.ts"],"names":[],"mappings":";AACA;;;;;;;;;;GAUG;AACH,OAAO,iBAAiB,CAAC"}

--- a/mcp-servers/src/bin.ts
+++ b/mcp-servers/src/bin.ts
@@ -10,9 +10,4 @@
  *
  * Copyright (c) 2026 Ascent Partners Foundation. MIT License.
  */
-import { main } from "./mcp-server.js";
-
-main().catch((err: unknown) => {
-  process.stderr.write(`Fatal error: ${String(err)}\n`);
-  process.exit(1);
-});
+import "./mcp-server.js";


### PR DESCRIPTION
## Summary

Fixes a startup crash in the MCP server bin entry: `node dist/bin.js` (and `npx @humanity4ai/mcp-servers`) died immediately with `Fatal error: Error: Already connected to a transport`. Root cause: `main()` was invoked twice on the same MCP `Server` instance — `mcp-server.ts` auto-runs `main()` at import (guarded by `NODE_ENV !== "test"`), and `bin.ts` imported and called `main()` again, so the second `server.connect(transport)` threw. Fix: `bin.ts` now only side-effect-imports `./mcp-server.js`, leaving the auto-run as the single entry. Zero behavior change for `pnpm start` (tsx `src/mcp-server.ts`) and the `NODE_ENV=test` path.

SDD artifacts (local, gitignored): `specs/deploy-verify-bin-fix/` (spec.md, plan.md, tasks.md).

## Contribution Type

- [x] Bug fix (eval harness, MCP server, schemas)

## Impact Area

- [x] `mcp-servers/` — contracts, schemas, or handlers

## Test Evidence

Local machine is slow — full vitest/eval gate delegated to CI on this PR (see Checks). Local fast verification:

```
$ pnpm --filter @humanity4ai/mcp-servers check   # tsc — pass
$ pnpm --filter @humanity4ai/mcp-servers build   # dist rebuilt — pass

$ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}' | node mcp-servers/dist/bin.js
Humanity4AI MCP Server v1.0.3 (JSON-RPC 2.0)
Tools: 9 registered
Transport: stdio (MCP SDK)
Ready — waiting for MCP client connections
{"result":{"protocolVersion":"2024-11-05",...,"serverInfo":{"name":"humanity4ai","version":"1.0.3"},...},"jsonrpc":"2.0","id":1}
```

Banner prints exactly once; no "Already connected to a transport" error; `initialize` handshake returns `serverInfo.name === "humanity4ai"`.

## Safety Checklist

- [x] No clinical diagnosis, treatment plans, or medical advice content
- [x] No legal advice content
- [x] Safety boundaries are explicit in all modified `skill.yaml` files (none modified)
- [x] Safety-critical skills unchanged
- [x] Crisis-adjacent content routes to professional resources (unchanged)

## Quality Checklist

- [x] `pnpm check` passes (TypeScript)
- [ ] `pnpm evals` passes (all gates) — delegated to CI (slow local machine)
- [ ] `pnpm test` passes (all tests) — delegated to CI (slow local machine)
- [x] No skill changes; CHANGELOG not required (no skill modified)

## Self-Certification

By opening this PR I confirm:

- This contribution does not introduce content that could be mistaken for clinical, medical, or legal advice
- I have read `CONTRIBUTING.md` and `SECURITY.md`
- The content is original or properly attributed with a compatible license