### PR TITLE
Ignore typescript major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@vitest/coverage-v8"
         update-types: ["version-update:semver-major"]
+      # typescript majors (incl. 7.x native preview) — update manually after toolchain review
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: npm
     directory: /evals
@@ -31,6 +34,8 @@ updates:
       - dependency-name: "vitest"
         update-types: ["version-update:semver-major"]
       - dependency-name: "@vitest/coverage-v8"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary

Env-config audit finding E-003 (MEDIUM). `dependabot.yml` ignores semver-major bumps for zod, @types/node, vitest, and @vitest/coverage-v8 — but not **typescript**, which produced PRs #147/#149 proposing `5.9.3 → 7.0.2`. TypeScript 7.x is the native (Go) preview line; merging it via automation risks breaking the whole toolchain (tsc build, tsx, vitest). Adds `typescript` semver-major ignore to both npm sections (/mcp-servers, /evals), matching the existing manual-review policy for toolchain majors.

## Contribution Type

- [x] Other: Dependabot config

## Impact Area

- [x] `.github/` — workflows or templates

## Test Evidence

Config-only change (YAML, no code path). CI on this PR verifies no workflow regression. Existing ignore-block pattern copied verbatim from the zod/vitest entries above it.

## Safety Checklist

- [x] No clinical diagnosis, treatment plans, or medical advice content
- [x] No legal advice content
- [x] No skill.yaml files modified
- [x] Safety-critical skills unchanged
- [x] Crisis-adjacent content unchanged

## Quality Checklist

- [x] `pnpm check` unaffected (no TS changes) — CI verifies
- [x] `pnpm evals` unaffected — CI verifies
- [x] `pnpm test` unaffected — CI verifies
- [x] No skill changes; CHANGELOG not required

## Self-Certification

By opening this PR I confirm:

- This contribution does not introduce content that could be mistaken for clinical, medical, or legal advice
- I have read `CONTRIBUTING.md` and `SECURITY.md`
- The content is original or properly attributed with a compatible license