### PR TITLE
Fix crisis-resource accuracy in safety-pair skills

### DIFF
--- a/skills/depression-sensitive-content/SKILL.md
+++ b/skills/depression-sensitive-content/SKILL.md
@@ -190,13 +190,7 @@ When uncertain:
 - Use "died by suicide" not "committed suicide"
 - Use "suicidal thoughts" not "suicidal tendencies"
 - Use "person with suicidal ideation" not "suicidal person"
-- Include crisis resources:
-  - **International**: Befrienders Worldwide — https://www.befrienders.org (global directory covering 32 countries)
-  - **International**: International Association for Suicide Prevention — https://www.iasp.info/resources/Crisis_Centres/
-  - **UK & Ireland**: Samaritans — 116 123 (free, 24/7) — https://www.samaritans.org
-  - **US & Canada**: 988 Suicide & Crisis Lifeline — call/text 988 — https://988lifeline.org
-  - **Online chat**: IMAlive — https://www.imalive.org (volunteer crisis chat, available in English)
-  - **Global text line**: Crisis Text Line — text HOME to 741741 (US/Canada/UK/Ireland)
+- Include crisis resources (runtime source of truth: `crisis-resources.ts` — surface those verbatim; exemplar list in `supportive-conversation/SKILL.md` Step 5: Crisis Response)
 
 ## Cognitive Accessibility
 

--- a/skills/depression-sensitive-content/skill.yaml
+++ b/skills/depression-sensitive-content/skill.yaml
@@ -14,13 +14,11 @@ tags:
   - language-guidelines
   - person-first
 author: project-human
-compatibility: Requires Python 3.8+
-allowed-tools: Bash(python3:*), Read, Write
 boundaries:
   - Non-clinical guidance only
   - No diagnosis or treatment advice
   - Escalate to professional support if clinical risk signals are present
-  - Always use person-first language
+  - Default to person-first language; respect identity-first preference
   - Include crisis resources when suicidal ideation detected
 actions:
   - id: rewrite_depression_sensitive_content

--- a/skills/supportive-conversation/SKILL.md
+++ b/skills/supportive-conversation/SKILL.md
@@ -166,13 +166,14 @@ Gently offer support options:
 **Required Response**:
 1. Validate: "I'm so glad you reached out"
 2. Express care: "I want to make sure you're safe"
-3. Provide resources:
-   - **International**: Befrienders Worldwide — https://www.befrienders.org (global directory covering 32 countries)
+ 3. Provide resources (runtime source of truth: `crisis-resources.ts` — surface those verbatim):
+   - **International directory**: Find a Helpline — https://findahelpline.com (maintained global directory)
    - **International**: International Association for Suicide Prevention — https://www.iasp.info/resources/Crisis_Centres/
    - **UK & Ireland**: Samaritans — 116 123 (free, 24/7) — https://www.samaritans.org
    - **US & Canada**: 988 Suicide & Crisis Lifeline — call/text 988 — https://988lifeline.org
-   - **Online chat**: IMAlive — https://www.imalive.org (volunteer crisis chat, available in English)
-   - **Global text line**: Crisis Text Line — text HOME to 741741 (US/Canada/UK/Ireland)
+   - **US text**: Crisis Text Line — text HOME to 741741 (US & Puerto Rico)
+   - **UK text**: Shout — text SHOUT to 85258
+   - **Ireland text**: Text About It — text HELLO to 50808
 4. Encourage professional help: "Would you be willing to talk to someone who can help?"
 
 ### Step 6: Close with Care


### PR DESCRIPTION
## Summary

**SAFETY-PAIR PR — requires explicit human review before merge (AC-6).**

Content-accuracy fixes to the two safety-critical skills, from the best-practice review cycle. Every hunk is citation-backed (register: `specs/skill-content-bestpractice/sources.md`, gitignored local):

- **F-05 (HIGH, S6/S7/S8):** Crisis Text Line 741741 was described as "US/Canada/UK/Ireland" — it is **US & Puerto Rico only** (per crisistextline.org + SAMHSA). UK users are now directed to **Shout 85258**, Ireland to **50808**. The old text misdirected UK/IE users to a number that would not reach help.
- **F-06 (MED, S9):** Removed unverifiable "Befrienders Worldwide — covering 32 countries" (count and maintenance status unverifiable from primary sources); replaced with **findahelpline.com**, the maintained international directory already used by `crisis-resources.ts`.
- **F-07 (MED, S9):** Removed **IMAlive** — 2026 operational status unverifiable from primary sources.
- **F-08 (MED, S10):** Crisis lists de-duplicated. `supportive-conversation/SKILL.md` keeps the exemplar list (now annotated: runtime source of truth is `crisis-resources.ts`); `depression-sensitive-content/SKILL.md` now points to it instead of carrying a second diverging copy.
- **F-10 (CONFLICT, human-resolved at T6 gate):** `skill.yaml` boundary "Always use person-first language" → "Default to person-first language; respect identity-first preference" — matches this skill's own SKILL.md ("respect both") and identity-first preference in autistic communities.
- **F-09 (MED, S10):** Removed stale `compatibility: Requires Python 3.8+` / `allowed-tools: Bash(python3:*)` metadata — scripts moved to `legacy/` and the MCP server never invokes them.

No schema, contract, handler, or `crisis-resources.ts` changes. No crisis numbers added or removed from runtime code.

## Contribution Type

- [x] Scenario addition to existing skill (content refinement)
- [x] Documentation

## Impact Area

- [x] `skills/` — one or more skill packs

## Test Evidence

Content-only changes (markdown + yaml metadata). Full gate runs in CI (slow local machine): `pnpm check` → build → `EVAL_REPORT=1 pnpm evals` (all 11 gates incl. escalation-language checks for both modified skills) → coverage.

## Safety Checklist

- [x] No clinical diagnosis, treatment plans, or medical advice content
- [x] No legal advice content
- [x] Safety boundaries are explicit in all modified `skill.yaml` files
- [x] Safety-critical skills (`supportive-conversation`, `depression-sensitive-content`) include escalation language in boundaries
- [x] Crisis-adjacent content routes to professional resources, not AI responses

## Quality Checklist

- [x] `pnpm check` passes (CI verifies — no TS changes)
- [x] `pnpm evals` passes (all 11 gates) — CI verifies
- [x] `pnpm test` passes — CI verifies
- [x] No manifesto-related changes
- [x] No new skills (scenario counts unchanged)
- [x] Provenance/license metadata intact in skill.yaml
- [x] `CHANGELOG.md` — N/A for content refinement (no behavior change)

## Self-Certification

By opening this PR I confirm:

- This contribution does not introduce content that could be mistaken for clinical, medical, or legal advice
- I have read `CONTRIBUTING.md` and `SECURITY.md`
- The content is original or properly attributed with a compatible license