### PR TITLE
Ground comms-family frameworks; dedupe empathetic crisis list

### DIFF
--- a/skills/conflict-de-escalation/SKILL.md
+++ b/skills/conflict-de-escalation/SKILL.md
@@ -73,7 +73,9 @@ This skill is grounded in the Humanity4AI core principles and the following skil
 
 ## De-escalation Framework
 
-### The VERB Model [CITATION NEEDED — verify against established frameworks: CPI, MOAB, LEAPS]
+### The VERB Model
+
+*Internal composite model. Underlying techniques are grounded in established frameworks: active listening and emotional labeling from FBI/CIT crisis-negotiation practice (also "tactical empathy", Voss), and Nonviolent Communication (Rosenberg: observation → feeling → need → request; note NVC's evidence base is promising but limited — mostly small studies).*
 
 **V - Validate**: Acknowledge their feelings and concerns
 - "I understand this is frustrating"
@@ -95,7 +97,9 @@ This skill is grounded in the Humanity4AI core principles and the following skil
 - "Here's what I can offer"
 - "We need to keep this respectful"
 
-### The GAIN Method [CITATION NEEDED — verify against established frameworks: CPI, MOAB, LEAPS]
+### The GAIN Method
+
+*Internal composite model — see framework grounding note under The VERB Model above.*
 
 **G - Gather**: Collect information about the situation
 - What's happening?

--- a/skills/empathetic-communication/SKILL.md
+++ b/skills/empathetic-communication/SKILL.md
@@ -231,14 +231,7 @@ Before offering solutions:
 
 ## Crisis Resources
 
-When conversations involve suicidal ideation, self-harm, or severe distress, include these resources:
-
-- **International**: Befrienders Worldwide — https://www.befrienders.org (global directory covering 32 countries)
-- **International**: International Association for Suicide Prevention — https://www.iasp.info/resources/Crisis_Centres/
-- **UK & Ireland**: Samaritans — 116 123 (free, 24/7) — https://www.samaritans.org
-- **US & Canada**: 988 Suicide & Crisis Lifeline — call/text 988 — https://988lifeline.org
-- **Online chat**: IMAlive — https://www.imalive.org (volunteer crisis chat, available in English)
-- **Global text line**: Crisis Text Line — text HOME to 741741 (US/Canada/UK/Ireland)
+When conversations involve suicidal ideation, self-harm, or severe distress, escalate via the `supportive_reply` action (priority-1 skill), which surfaces localized crisis resources from the runtime source of truth (`crisis-resources.ts`). Exemplar list: `supportive-conversation/SKILL.md` Step 5: Crisis Response.
 
 ---
 


### PR DESCRIPTION
## Summary

Communication-family content fixes from the best-practice review cycle (citations: `specs/skill-content-bestpractice/sources.md`, local):

- **F-11 (MED, S10):** `empathetic-communication/SKILL.md` carried a third diverging copy of the crisis-resource list (including the inaccurate "741741 US/Canada/UK/Ireland" and unverifiable Befrienders/IMAlive entries). Crisis signposting belongs to the priority-1 `supportive_reply` skill — the section now points there and to the `crisis-resources.ts` single source of truth.
- **F-13 (LOW, S13/S14):** The VERB and GAIN de-escalation models were marked `[CITATION NEEDED]` by their original authors. Research found no such established frameworks — the markers are replaced with honest grounding: internal composite models whose techniques derive from **FBI/CIT crisis-negotiation practice** (active listening, labeling, tactical empathy) and **NVC** (Rosenberg: observation→feeling→need→request, with evidence-limit caveat). Model content unchanged (verified as consistent with those frameworks).

No code, schema, or contract changes.

## Contribution Type

- [x] Documentation
- [x] Scenario addition to existing skill (content refinement)

## Impact Area

- [x] `skills/` — one or more skill packs

## Test Evidence

Content-only changes; full gate in CI (slow local machine): check → build → evals → coverage.

## Safety Checklist

- [x] No clinical diagnosis, treatment plans, or medical advice content
- [x] No legal advice content
- [x] Safety boundaries explicit in modified skill.yaml files (none modified)
- [x] Safety-critical skills unchanged in this PR (covered by #164)
- [x] Crisis-adjacent content routes to professional resources, not AI responses

## Quality Checklist

- [x] `pnpm check` / `pnpm evals` / `pnpm test` — CI verifies (no TS changes)
- [x] No new skills; provenance intact; CHANGELOG N/A

## Self-Certification

By opening this PR I confirm:

- This contribution does not introduce content that could be mistaken for clinical, medical, or legal advice
- I have read `CONTRIBUTING.md` and `SECURITY.md`
- The content is original or properly attributed with a compatible license