### PR TITLE
chore: add devcontainer for GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "humanity4ai",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:22",
+  "postCreateCommand": "corepack enable && pnpm install --frozen-lockfile",
+  "customizations": {
+    "vscode": {
+      "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `.devcontainer/devcontainer.json` so the repo boots in GitHub Codespaces with dependencies installed — part of the compute-offload initiative (local machine becomes thin client).

- Node 22 devcontainer image (matches CI matrix)
- `corepack enable && pnpm install --frozen-lockfile` post-create
- ESLint + Prettier extensions

Config-only change; no application code. Final verification (boot Codespace, run `pnpm check` + `pnpm test`) to be done manually after merge per offload spec AC-5.