### PR TITLE
chore: add sshd feature to devcontainer for CLI access

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,11 @@
 {
   "name": "humanity4ai",
   "image": "mcr.microsoft.com/devcontainers/typescript-node:22",
+  "features": {
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "latest"
+    }
+  },
   "postCreateCommand": "corepack enable && pnpm install --frozen-lockfile",
   "customizations": {
     "vscode": {


### PR DESCRIPTION
Adds the sshd devcontainer feature to `.devcontainer/devcontainer.json` — `gh codespace ssh` fails without it ("failed to start SSH server"). Required for CLI-based verification and remote development per the compute-offload initiative (AC-5). Config-only change.