### PR TITLE
feat: consolidate skill repos + README/site discoverability overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased]
+
+### Consolidation
+- Merged `wcag-aaa-web-design` (13⭐, archived) into `skills/accessibility/`: 10 reference guides (WCAG-AAA checklist, ARIA patterns, corporate design system, form patterns, security error handling, application states, data presentation, navigation, responsive breakpoints, UX patterns) + 10 AAA-verified templates (tokens.css with 7:1 contrast palette, components.css, HTML partials, main.js)
+- Merged `depression-sensitive-web-content` (archived) into `skills/depression-sensitive-content/references/implementation-guide.md`: 7 rewrite principles with clinical rationale, 15 worked examples, standards traceability matrix (WCAG 2.2 / COGA / ISO 9241-110 / ISO/IEC 30071-1), 40+ item audit checklist, localization guidance
+- Archived `nvda-wcag22-testing` (empty placeholder) with redirect notice
+- Salvaged launch marketing packs (Dev.to drafts, Reddit/X/LinkedIn post packs, directory submission template) into `docs/marketing/`
+- `check_contrast.py` (AAA contrast checker with auto-suggestion engine) included in `skills/accessibility/templates/`
+
+### Discoverability
+- README restructured: 9-skill table above the fold, star CTA, star-history chart, one-command quick start, Share-on-X link
+- GitHub topics updated to 20 high-search tags (added mcp-server, llm, claude, openai, npm-package)
+- Site landing page: 9-skill card grid with category tags, npm CTA
+
 ## [1.0.0] — 2026-05-26
 
 ### Stable Release

--- a/README.md
+++ b/README.md
@@ -1,31 +1,50 @@
-# Humanity4AI
+# Humanity4AI ⭐
 
-Humanity4AI is an open, community-driven project that provides reusable "humanity skills" for AI systems and agents.
+**9 humanity skills for AI agents** — crisis detection, accessibility auditing, empathy, cultural sensitivity, and more. Ready-to-use via MCP, npm, or direct prompting.
 
 [![CI](https://github.com/humanity4ai/project_human/actions/workflows/ci.yml/badge.svg)](https://github.com/humanity4ai/project_human/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/humanity4ai/project_human)](https://github.com/humanity4ai/project_human/releases)
 [![npm](https://img.shields.io/npm/v/@humanity4ai/mcp-servers?color=0f766e)](https://www.npmjs.com/package/@humanity4ai/mcp-servers)
-[![License](https://img.shields.io/badge/license-MIT-0f766e)](LICENSE)
-[![Issues](https://img.shields.io/github/issues/humanity4ai/project_human)](https://github.com/humanity4ai/project_human/issues)
+[![License: MIT](https://img.shields.io/badge/license-MIT-0f766e)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/humanity4ai/project_human)](https://github.com/humanity4ai/project_human/releases)
 [![Contributors](https://img.shields.io/github/contributors/humanity4ai/project_human)](https://github.com/humanity4ai/project_human/graphs/contributors)
-[![Pages](https://img.shields.io/badge/docs-GitHub%20Pages-1f2937)](https://humanity4ai.github.io/project_human/)
-[![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux%20%7C%20Android%20%7C%20iOS-0f766e)](https://github.com/humanity4ai/project_human)
 [![CodeQL](https://github.com/humanity4ai/project_human/actions/workflows/codeql.yml/badge.svg)](https://github.com/humanity4ai/project_human/actions/workflows/codeql.yml)
 
-## Get Started in 3 Steps
+---
 
-**Prerequisites:** Node.js >= 20 | pnpm >= 10 | Windows, macOS, or Linux
+## Skills at a Glance
+
+| Skill | Category | What it does |
+|-------|----------|-------------|
+| 🛡️ **Supportive Reply** | Emotional Safety | Detects crisis signals, generates supportive responses with escalation guidance |
+| 📝 **Safe Content Rewriter** | Emotional Safety | Audits and rewrites text to remove harmful, stigmatising, or triggering patterns |
+| ♿ **Accessibility Audit** | Accessibility | Scores pages against all 86 WCAG 2.2 success criteria (A/AA/AAA) |
+| 🧠 **Cognitive Accessibility** | Cognitive Support | Audits content for reading level, structure, and cognitive load |
+| 🌍 **Cultural Context Check** | Cultural Context | Flags cultural sensitivity issues for a given audience and region |
+| 🔥 **De-escalation Plan** | Conflict Navigation | Generates structured de-escalation plans calibrated to conflict intensity |
+| 💬 **Empathetic Reframe** | Communication | Reframes messages with genuine empathy, catching hollow empathy patterns |
+| 🧩 **Neurodiversity Design** | Neurodiversity | Audits UIs for ADHD, autism, dyslexia, and sensory sensitivity |
+| 👶 **Age-Inclusive Design** | Age Inclusion | Audits user flows for age barriers across children, adults, and older users |
+
+> ⭐ **If you find this useful, a star helps others discover it**
+
+[![Star History Chart](https://api.star-history.com/svg?repos=humanity4ai/project_human&type=Date)](https://www.star-history.com/#humanity4ai/project_human&Date)
+
+---
+
+## Quick Start
 
 ```bash
-# Step 1 — Install & Verify
-git clone https://github.com/humanity4ai/project_human.git && cd project_human && pnpm install && pnpm check && pnpm evals
-
-# Step 2 — Start the MCP server
-pnpm start
-
-# Step 3 — Configure your agent
+# One command — clone, install, verify, start
+git clone https://github.com/humanity4ai/project_human.git && cd project_human && pnpm install && pnpm check && pnpm evals && pnpm start
 ```
-Add to your MCP client config:
+
+Or use the npm package directly:
+
+```bash
+npx @humanity4ai/mcp-servers
+```
+
+Then add to your MCP client config:
 
 ```json
 {
@@ -39,242 +58,80 @@ Add to your MCP client config:
 }
 ```
 
-All 9 humanity skills are now discoverable via `tools/list` and invocable via `tools/call`.
+All 9 skills are now discoverable via `tools/list` and invocable via `tools/call`.
 
----
-## Three Ways to Use Humanity4AI Skills
+**Docker**: `docker compose up`
 
-This repository provides **9 Humanity Skills** — reusable, testable specifications for humane AI behaviour covering empathy, accessibility, grief support, cultural sensitivity, and more. There are three distinct ways to access these skills, depending on your AI platform and its capabilities.
-
-| Method | Skills Access | Best for... | How it Works |
-|---|---|---|---|
-| **1. MCP Server** | All 9 skills as invocable tools | Developer tools (VS Code, Cursor) and agents (Manus AI, OpenCode) | Run a local server that exposes all 9 skills as tools via the Model Context Protocol (MCP). |
-| **2. LLM Prompting** | Any skill via context window | Web chat AIs (Claude, Gemini, ChatGPT) | Provide the content of `llms.txt` or a specific `SKILL.md` directly in the chat context. |
-| **3. Local Files** | Any skill via filesystem | CLI tools without web access (OpenCode) | Clone the repository and point the tool to the relevant `SKILL.md` file path. |
+**Prerequisites**: Node.js >= 20, pnpm >= 10 | Windows, macOS, Linux, Android, iOS
 
 ---
 
-### Method 1: MCP Server (for Developer Tools & Agents)
+## Three Ways to Use
 
-This is the most reliable and structured way to use the skills.
+| Method | Best for | How |
+|--------|----------|-----|
+| **MCP Server** | VS Code, Cursor, Claude Code, Copilot, Manus AI, OpenCode | Start the server, configure your agent's MCP client |
+| **LLM Prompting** | ChatGPT, Claude, Gemini (web chat) | Share `llms.txt` or paste `llms-full.txt` into the chat |
+| **Local Files** | Offline CLI tools | Clone the repo, point your tool at the `skills/` directory |
 
-**Step 1 — Start the server:**
-
-```bash
-# From the project root
-pnpm start
-```
-
-**Step 2 — Configure your agent:**
-
-Add the following to your agent's MCP configuration file. See the [Agent Adapter Guide](docs/agent-adapters.md) for platform-specific file paths.
-
-```json
-{
-  "mcpServers": {
-    "humanity4ai": {
-      "command": "pnpm",
-      "args": ["--filter", "@humanity4ai/mcp-servers", "start"],
-      "cwd": "/path/to/project_human"
-    }
-  }
-}
-```
-
-Once configured, all 9 skills are discoverable via `tools/list` and invocable via `tools/call`.
+See [Agent Adapter Guide](docs/agent-adapters.md) for platform-specific setup instructions.
 
 ---
 
-### Method 2: LLM Prompting (for Web Chat AIs)
+## Why Humanity4AI?
 
-This method is for web-based chat interfaces like Claude, Gemini, and ChatGPT. It relies on the LLM's ability to read context provided directly in the prompt.
+AI agents are everywhere — but they're not always humane. Humanity4AI gives agents **reusable, tested skills** for the moments that matter:
 
-**Step 1 — Provide the context:**
+- An agent detects a user in crisis → **Supportive Reply** generates an appropriate response and escalates to qualified help
+- A UI is inaccessible to screen readers → **Accessibility Audit** scores it against WCAG 2.2 and provides remediation
+- Content uses stigmatising language → **Safe Content Rewriter** flags and rewrites harmful patterns
+- A conflict is escalating → **De-escalation Plan** generates structured, non-coercive guidance
 
-Tell your LLM:
+Every skill includes:
+- **Explicit safety boundaries** — what the skill can and cannot do
+- **Uncertainty disclosure** — confidence level stated upfront (low/medium/high)
+- **Evaluation gates** — automated baseline checks for quality
 
-> "You are an AI assistant with the Humanity4AI skillset. Your primary goal is to interact with users in a humane, ethical, and context-aware manner. Start by reading the `llms.txt` file at the root of this repository to understand your capabilities, then apply the principles and skills you find there in our conversation."
-
-**Step 2 — Verify and interact:**
-
-The LLM should acknowledge the context and begin applying the principles. Note that not all web chat AIs can fetch URLs. If the LLM cannot access `llms.txt`, you can paste the content of `llms-full.txt` directly into the chat.
-
----
-
-### Method 3: Local Files (for Offline CLI Tools)
-
-This method is for tools like OpenCode that operate on a local filesystem and do not have web access.
-
-**Step 1 — Clone the repository:**
-
-```bash
-git clone https://github.com/humanity4ai/project_human.git
-```
-
-**Step 2 — Point your tool to the local path:**
-
-Follow the instructions for your specific tool to have it read the files from the cloned repository directory.
+These skills are **rule-based and non-clinical** — they do not provide diagnosis, treatment, or professional medical/legal advice.
 
 ---
 
-## Get Involved
+## Supported Platforms
 
-- **Contributors**: [Contributing Guide](CONTRIBUTING.md)
-- **Integrators**: [Agent Adapter Guide](docs/agent-adapters.md)
-- **Team**: [Operations Plan](docs/OPERATIONS.md)
-- **Public Site**: <https://humanity4ai.github.io/project_human/>
+OpenCode · Claude Code · Microsoft Copilot · Manus AI · OpenClaw · ChatGPT · Claude · Gemini
 
-## Prerequisites
+---
 
-- **Node.js** >= 20
-- **pnpm** >= 10
-
-## Quick Start (for local development)
+## Contribute
 
 ```bash
-git clone https://github.com/humanity4ai/project_human.git
-cd project_human
-pnpm install
-pnpm check
-pnpm evals
-```
-
-### For AI Agents — Standard MCP SDK (JSON-RPC 2.0)
-
-Start the standard MCP server compatible with Claude Code, Copilot, Manus AI, OpenCode, and any MCP SDK client:
-
-```bash
-pnpm start
-```
-
-Configure your agent by adding this to your MCP client config:
-
-```json
-{
-  "mcpServers": {
-    "humanity4ai": {
-      "command": "pnpm",
-      "args": ["--filter", "@humanity4ai/mcp-servers", "start"],
-      "cwd": "/path/to/project_human"
-    }
-  }
-}
-```
-
-All 9 humanity skills are discoverable via `tools/list` and invocable via `tools/call`.
-See [`mcp-servers/README.md`](mcp-servers/README.md) for full protocol details and tool reference.
-
-Full install and deploy guide: [`INSTALL.md`](docs/INSTALL.md)
-
-## Docker (one command)
-
-```bash
-docker compose up
-```
-
-## MCP Runtime
-
-`mcp-servers` exposes all 9 skill actions via the standard MCP SDK JSON-RPC 2.0 protocol:
-
-| Server | Command | Protocol |
-|--------|---------|----------|
-| **Standard MCP SDK** | `pnpm start` | JSON-RPC 2.0 over stdio |
-
-All tools include input validation, structured responses, safety boundaries, and uncertainty disclosure.
-See [`mcp-servers/README.md`](mcp-servers/README.md) for the full tool reference.
-
-## Alternative: Prompt Engineering
-
-If your AI agent doesn't support MCP or skills, you can still use Humanity4AI by providing project content directly in the conversation context. This is less reliable than the MCP server but provides a good fallback.
-
-### How It Works
-
-You (the user) manually share the relevant file contents with your LLM. The LLM then applies those principles when responding to you. The best way to do this is to point the LLM to the `llms.txt` file.
-
-### What to Share
-
-Tell your LLM:
-
-> "You are an AI assistant with the Humanity4AI skillset. Your primary goal is to interact with users in a humane, ethical, and context-aware manner. Start by reading the `llms.txt` file at the root of this repository to understand your capabilities, then apply the principles and skills you find there in our conversation."
-
-Alternatively, you can provide the full context in one go:
-
-> "Here is the full context for the Humanity4AI skillset. Apply these principles and skills in our conversation:
-> 
-> [Paste the entire content of `llms-full.txt` here]"
-
-## Integrations
-
-- OpenCode
-- Claude Code
-- Microsoft Copilot ecosystem
-- Manus AI
-- OpenClaw
-
-See implementation notes in `docs/integrations.md` and `docs/agent-adapters.md`.
-
-## Contribute in 10 Minutes
-
-**Step 1 — Pick a task**
-
-Browse [open starter issues](https://github.com/humanity4ai/project_human/issues/new/choose) or see `docs/good-first-issues.md` for curated tasks.
-
-**Step 2 — Fork, branch, and implement**
-
-```bash
-# Clone your fork
 git clone https://github.com/<your-username>/project_human.git
 cd project_human
-
-# Branch from main (the default branch)
-git checkout main
 git checkout -b my-contribution
-
-# Copy the skill template if adding a new skill
+# Copy the skill template if adding a new skill:
 cp -r templates/skill skills/my-skill-name
-
-# Run all checks before opening a PR
-pnpm check && pnpm evals && pnpm test
+pnpm check && pnpm evals && pnpm test  # Run all checks before PR
 ```
 
-**Step 3 — Open a PR targeting `main`**
-
-```bash
-gh pr create \
-  --base main \
-  --title "Add: my contribution" \
-  --body "Closes #<issue-number>"
-```
-
-Or open via GitHub UI — the default base branch is `main`.
-
-**Troubleshooting**
+Open a PR targeting `main`. Browse [good first issues](https://github.com/humanity4ai/project_human/issues?q=is%3Aopen+label%3A%22good+first+issue%22) or read the [Contributing Guide](CONTRIBUTING.md).
 
 | Error | Fix |
 |-------|-----|
-| `ERR_PNPM_OUTDATED_LOCKFILE` | Run `pnpm install` (without `--frozen-lockfile`) to update the lockfile, then commit `pnpm-lock.yaml` |
-| `pnpm: command not found` | Run `npm install -g pnpm` |
-| `pnpm evals` fails | Run `EVAL_REPORT=1 pnpm evals` — the report at `evals/reports/latest.md` shows which gates failed and why |
+| `ERR_PNPM_OUTDATED_LOCKFILE` | Run `pnpm install`, then commit `pnpm-lock.yaml` |
+| `pnpm: command not found` | `npm install -g pnpm` |
+| `pnpm evals` fails | `EVAL_REPORT=1 pnpm evals` — see `evals/reports/latest.md` |
 
-## Traction and Roadmap
+---
 
-- 14-day launch cadence: `docs/traction-14-day.md`
-- Quality gates: `docs/quality-gates.md`
-- Release roadmap: `docs/ROADMAP.md`
+## Resources
 
-## How To Help This Week
+- [Contributing Guide](CONTRIBUTING.md)
+- [Agent Adapter Guide](docs/agent-adapters.md)
+- [Governance](docs/GOVERNANCE.md)
+- [Roadmap](docs/ROADMAP.md)
+- [Release Process](docs/release-process.md)
+- [Public Site](https://humanity4ai.github.io/project_human/)
 
-- Good first issues: https://github.com/humanity4ai/project_human/issues?q=is%3Aopen+label%3A%22good+first+issue%22
-- Help wanted: https://github.com/humanity4ai/project_human/issues?q=is%3Aopen+label%3A%22help+wanted%22
+---
 
-## Package Release
-
-`mcp-servers` is now prepared as a publishable package with build artifacts and schema exports.
-
-- Build package: `pnpm --filter @humanity4ai/mcp-servers build`
-- Create tarball: `pnpm --filter @humanity4ai/mcp-servers pack`
-- Release guide: `docs/package-release.md`
-
-## Safety Position
-
-Humanity4AI includes non-clinical support-oriented skills. It does not provide diagnosis, treatment, or professional medical/legal advice.
+**[Share on X](https://twitter.com/intent/tweet?text=Humanity4AI%20%E2%80%94%209%20humanity%20skills%20for%20AI%20agents%20%F0%9F%A4%9D%0A%0ACrisis%20detection%2C%20WCAG%20audits%2C%20empathy%2C%20cultural%20sensitivity%2C%20and%20more.%0A%0Ahttps%3A%2F%2Fgithub.com%2Fhumanity4ai%2Fproject_human)** · MIT License · Copyright © 2026 Ascent Partners Foundation

--- a/docs/marketing/devto-article-drafts.md
+++ b/docs/marketing/devto-article-drafts.md
@@ -1,0 +1,441 @@
+# Dev.to Article Drafts — DS-WCS Skill
+
+Three articles ready for direct posting to Dev.to. Each is written in Dev.to markdown format. Tags are listed at the top of each article — enter them in the Dev.to tag field, not in the body.
+
+---
+
+## Article 1 — Technical walkthrough
+
+**Title:** How to audit your UI content for cognitive accessibility in 20 minutes
+
+**Tags:** `accessibility` `ux` `opencode` `webdev`
+
+**Cover image suggestion:** A side-by-side before/after of an error message — plain text screenshot is sufficient.
+
+---
+
+Most accessibility audits focus on colour contrast, keyboard navigation, and screen reader compatibility.
+
+They miss the words.
+
+This article walks through a 20-minute cognitive accessibility audit of a fictional checkout flow using the DS-WCS open-source skill for OpenCode. By the end you will have a working audit setup, a prioritised list of findings, and concrete rewrites to implement.
+
+---
+
+### What is cognitive accessibility?
+
+Cognitive accessibility addresses how well an interface works for users with conditions affecting executive function — depression, anxiety, ADHD, acquired brain injury, and others.
+
+Depression affects 280 million people globally (WHO, 2023). It impairs:
+
+- **Working memory** — holding information across steps
+- **Executive function** — planning, decision-making, task sequencing
+- **Processing speed** — absorbing and acting on information
+- **Emotional regulation** — sensitivity to shame, urgency, and negative feedback
+
+Interfaces that ignore these differences do not just create friction. They create barriers that cause task abandonment — particularly on high-stakes flows like checkout, account creation, and healthcare forms.
+
+---
+
+### The demo component
+
+Here is a fictional checkout error state. It is representative of patterns found on real production interfaces:
+
+```tsx
+// CheckoutError.tsx
+export function CheckoutError() {
+  return (
+    <div className="error-container">
+      <h2>Oops! Something went wrong!</h2>
+      <p>You entered invalid payment details. Please try again immediately — your cart will expire soon!</p>
+      <p>Error code: ERR_PAYMENT_422</p>
+      <button>OK</button>
+    </div>
+  );
+}
+```
+
+Five issues visible before even running the audit:
+
+1. "Oops!" — dismissive opener
+2. "Something went wrong!" — vague, no recovery
+3. "You entered invalid payment details" — second-person blame
+4. "try again immediately" + "cart will expire soon" — urgency pressure stacked twice
+5. `ERR_PAYMENT_422` — technical jargon with no plain language equivalent
+6. "OK" button — generic label, no outcome description
+
+---
+
+### Install DS-WCS
+
+DS-WCS is an OpenCode skill. Install it project-locally:
+
+```bash
+mkdir -p .opencode/skills
+git clone https://github.com/simonplmak-cloud/depression-sensitive-web-content.git \
+  .opencode/skills/depression-sensitive-web-content
+```
+
+Or globally, for use across all projects:
+
+```bash
+mkdir -p ~/.config/opencode/skills
+git clone https://github.com/simonplmak-cloud/depression-sensitive-web-content.git \
+  ~/.config/opencode/skills/depression-sensitive-web-content
+```
+
+---
+
+### Run the audit
+
+Open OpenCode in your project directory and ask:
+
+```
+Audit src/components/CheckoutError.tsx for depression-sensitive content issues
+```
+
+DS-WCS will load the skill, read the file, apply the 40-item audit checklist, and return findings organised by severity with standards citations.
+
+---
+
+### Sample output
+
+```markdown
+## Findings
+
+### HIGH Severity
+
+- **CheckoutError.tsx:5** — Second-person blame language
+  - Original: "You entered invalid payment details."
+  - Standards: WCAG 3.3.1, COGA Objective 2, ISO 9241-110 Clause 5.7
+
+- **CheckoutError.tsx:5** — Stacked urgency pressure
+  - Original: "try again immediately — your cart will expire soon!"
+  - Standards: WCAG 2.2.6, ISO 9241-110 Clause 5.5, COGA Objective 4
+
+- **CheckoutError.tsx:7** — Generic button label with no outcome description
+  - Original: "OK"
+  - Standards: WCAG 2.4.6, ISO 9241-110 Clause 5.2
+
+### MEDIUM Severity
+
+- **CheckoutError.tsx:3** — Dismissive opener with exclamation
+  - Original: "Oops! Something went wrong!"
+  - Standards: ISO/IEC 30071-1 Clause 9.1, COGA Objective 1
+
+- **CheckoutError.tsx:6** — Technical jargon without plain language
+  - Original: "Error code: ERR_PAYMENT_422"
+  - Standards: WCAG 3.3.1, COGA Objective 1
+
+## Recommended Rewrites
+
+**Before:**
+"Oops! Something went wrong! You entered invalid payment details.
+Please try again immediately — your cart will expire soon!"
+
+**After:**
+"Payment not processed.
+
+Your card details could not be verified. Check the card number, expiry date,
+and security code, then try again.
+
+Your cart is saved for 30 minutes.
+
+[Try payment again]  [Use a different card]"
+
+**Rationale:**
+- Removed blame attribution and exclamation points
+- Replaced stacked urgency with a calm, specific timeframe
+- Added two self-descriptive recovery actions
+- Replaced "OK" with outcome-specific button labels
+- Technical error code moved to secondary position if needed for support
+
+**Standards:**
+- WCAG 3.3.1 (Error Identification)
+- WCAG 3.3.3 (Error Suggestion)
+- WCAG 2.4.6 (Headings and Labels)
+- W3C COGA Objective 2: Help users avoid mistakes
+- ISO 9241-110: Error tolerance, Self-descriptiveness, Controllability
+```
+
+---
+
+### The rewritten component
+
+```tsx
+// CheckoutError.tsx — revised
+export function CheckoutError({ cartExpiryMinutes = 30 }) {
+  return (
+    <div className="error-container">
+      <h2>Payment not processed</h2>
+      <p>
+        Your card details could not be verified. Check the card number,
+        expiry date, and security code, then try again.
+      </p>
+      <p>Your cart is saved for {cartExpiryMinutes} minutes.</p>
+      <div className="error-actions">
+        <button className="primary">Try payment again</button>
+        <button className="secondary">Use a different card</button>
+      </div>
+    </div>
+  );
+}
+```
+
+---
+
+### What the audit covers
+
+DS-WCS checks 40+ items across these content categories:
+
+| Category | Example checks |
+|---|---|
+| Error messages | Blame language, missing recovery, technical jargon |
+| CTAs | Generic labels, urgency language, ambiguous groupings |
+| Forms | Memory-dependent instructions, hidden requirements, conditional fields |
+| Notifications | Urgency markers, dismissive tone |
+| Empty states | Obligation language, shame framing |
+| Onboarding | Premature disclosure, missing progress indicators |
+| Help text | Inconsistent placement, absence of inline guidance |
+
+---
+
+### Install, run, contribute
+
+- **GitHub:** github.com/simonplmak-cloud/depression-sensitive-web-content
+- **Install:** One `git clone` to `.opencode/skills/`
+- **License:** MIT — free to use, fork, and extend
+- **Contributing:** 15 before/after examples already included; PRs welcome for new content categories
+
+If you audit your own interfaces and find patterns not covered by the checklist, open an issue. The goal is a community-maintained resource that covers every common interface context.
+
+---
+
+## Article 2 — Conceptual explainer
+
+**Title:** Depression-sensitive design: what it is, why it matters, and how to implement it
+
+**Tags:** `accessibility` `ux` `mentalhealth` `inclusivedesign`
+
+**Cover image suggestion:** A calm, minimal interface mockup — or the DS-WCS GitHub README header.
+
+---
+
+There is a category of accessibility that most teams never audit.
+
+It is not about colour contrast ratios or keyboard traps. It does not require assistive technology testing. It does not show up in automated scans.
+
+It is about the emotional and cognitive impact of the words you put on screen.
+
+This is depression-sensitive design.
+
+---
+
+### What depression does to users
+
+Depression is not just sadness. It is a neurological condition that measurably impairs cognitive function, including:
+
+**Working memory** — the ability to hold information in mind across steps. A user with depression may forget what they entered three fields ago. They may lose their place in a multi-step form. They may not be able to recall a policy number they looked up 30 seconds before.
+
+**Executive function** — planning, sequencing, and decision-making. A user with depression may struggle to determine what to do next when faced with a vague error message. They may be unable to generate a recovery path independently.
+
+**Processing speed** — absorbing and acting on information. Time pressure compounds this. A countdown timer on a checkout form is not a neutral design choice for a user whose processing speed is already impaired.
+
+**Emotional regulation** — sensitivity to shame, blame, and negative feedback. A user experiencing depression is more susceptible to the emotional content of interface language. "You entered invalid data" is not a neutral statement. It attributes failure to the user. That attribution, however unintentional, can trigger a shame response that ends the session.
+
+---
+
+### Seven principles
+
+Depression-sensitive design applies seven evidence-based principles to UI content:
+
+**1. Remove shame and blame language**
+Attribute errors to system conditions or input format, not the user.
+- "You entered invalid data" → "Email format not recognised"
+- "You broke something" → "Page not found"
+
+**2. Reduce urgency pressure**
+Remove countdown timers, "ACT NOW" language, and artificial scarcity from cognitive tasks.
+- "Sign up now!" → "Create account"
+- "60 seconds remaining!" → "Your session will expire in 5 minutes"
+
+**3. Self-descriptive call-to-action labels**
+Button labels should answer: "What happens when I click this?"
+- "Submit" → "Create account"
+- "OK" → "Try payment again"
+- "Go" → "Start free trial"
+
+**4. Error recovery templates**
+Every error message must answer: "What do I do now?"
+- "Invalid" → "Email format not recognised. Use this format: name@domain.com"
+- "Error occurred" → "System error. Try again in 5 minutes or contact support."
+
+**5. Reduce memory reliance**
+Display necessary information rather than requiring recall.
+- "Call for your policy number" → "Policy number (found on your insurance card, top right)"
+- Show password requirements before entry, not after failure
+
+**6. Scannable plain language**
+Short paragraphs. Bullet points. Key information first.
+- 8th grade reading level or lower for instructional content
+- Headings to break long forms into navigable sections
+
+**7. Calm UI microcopy**
+Neutral-to-supportive tone. No excessive enthusiasm or alarm.
+- "Congratulations!!!" → "Account created successfully"
+- "CRITICAL ERROR" → "System error (500)"
+- "Amazing! You did it!" → "Appointment confirmed"
+
+---
+
+### The standards behind the principles
+
+These principles are not opinions. They map to four international standards:
+
+| Standard | What it covers |
+|---|---|
+| **WCAG 2.2** | Error identification, error suggestion, labels, timeouts, redundant entry |
+| **W3C COGA** | Cognitive and learning disability user needs; help users avoid mistakes, find what they need, complete tasks |
+| **ISO 9241-110** | Dialogue principles: self-descriptiveness, controllability, error tolerance, conformity with expectations |
+| **ISO/IEC 30071-1** | Accessibility policy: emotional safety, inclusive language, dignity in user-facing communications |
+
+Every finding from a DS-WCS audit maps to specific criteria in these standards. This means every change is traceable and defensible — whether for a design review, an accessibility audit, or an ESG disclosure.
+
+---
+
+### Where to start
+
+A practical starting point for any team:
+
+1. Pull the last 10 error messages from your production interface
+2. Check each one against three questions:
+   - Does it use second-person blame? ("You entered", "You broke", "Your input is wrong")
+   - Does it include a recovery path?
+   - Does it use exclamation points?
+
+If any answer is yes/no/yes — you have a HIGH severity finding.
+
+The DS-WCS open-source skill automates this audit for teams using OpenCode. Install with one `git clone`, run against any component or file, and receive a findings report with standards citations and rewrite recommendations.
+
+→ github.com/simonplmak-cloud/depression-sensitive-web-content
+
+---
+
+### A note on scope
+
+Depression-sensitive design is a UX and content accessibility discipline. It is not a clinical practice.
+
+DS-WCS does not diagnose depression. It does not treat depression. It does not provide mental health advice.
+
+It addresses one specific domain: the content layer of digital interfaces, and how to make that content less harmful and more usable for people with cognitive differences.
+
+That is a design responsibility, not a medical one.
+
+---
+
+## Article 3 — ESG/SDG narrative for developers
+
+**Title:** Why developers should care about SDGs — and how one open-source skill connects to SDG 3
+
+**Tags:** `accessibility` `opensource` `sustainability` `webdev`
+
+**Cover image suggestion:** UN SDG colour wheel or a clean SDG 3 tile graphic.
+
+---
+
+Most developers encounter ESG and SDGs in one of three contexts:
+
+1. A company all-hands where leadership announces sustainability commitments
+2. A job description that mentions "responsible tech" as a value
+3. A compliance checkbox somewhere in a procurement process
+
+In all three cases, the connection to the actual work of writing code feels abstract.
+
+This article makes it concrete. Specifically: how a free open-source tool for UI content design connects directly to UN Sustainable Development Goal 3 — and why that connection matters for the products you build.
+
+---
+
+### What SDG 3 actually says
+
+SDG 3 is "Good Health and Well-Being." Most coverage focuses on vaccine access, maternal mortality, and disease prevention.
+
+Target 3.4 reads: *"By 2030, reduce by one third premature mortality from non-communicable diseases through prevention and treatment and promote mental health and well-being."*
+
+That last clause — promote mental health and well-being — applies beyond clinical settings. It applies to the environments people inhabit daily. And in 2026, those environments are increasingly digital.
+
+Digital interfaces are not neutral. The language they use, the friction they create, and the emotional tone they set have measurable effects on users with mental health conditions.
+
+---
+
+### The cognitive impact of bad UX copy
+
+Depression affects approximately 280 million people globally (WHO, 2023). It impairs working memory, executive function, processing speed, and emotional regulation.
+
+When a digital interface uses blame language in error messages, it activates the brain's threat response. For users without depression, that is friction. For users with depression, that impairment compounds existing cognitive deficits — and frequently ends the session.
+
+This is not theoretical. It is documented in cognitive psychology research and referenced in standards from the W3C Cognitive Accessibility Task Force (COGA).
+
+Here are three patterns that cause measurable harm:
+
+**Blame language:** "You entered invalid data" attributes failure to the user. It induces shame, which impairs problem-solving.
+
+**Urgency pressure:** "60 seconds remaining! Act now!" creates artificial time pressure that compounds cognitive load for users whose processing speed is already impaired.
+
+**Missing recovery paths:** "Error occurred" with no next step forces users to independently generate a solution — a task that executive function impairments make genuinely difficult.
+
+---
+
+### Where SDG 10 comes in
+
+SDG 10 — Reduced Inequalities — Target 10.3 addresses non-discrimination by disability status.
+
+Cognitive disabilities, including those related to depression and anxiety, are among the most prevalent disability categories globally. When digital interfaces are systematically inaccessible to users with these conditions, that is a form of structural exclusion.
+
+Fixing it is not a grand gesture. It is rewriting a button label and adding a recovery path to an error message.
+
+---
+
+### The open-source connection
+
+DS-WCS (Depression-Sensitive Web Content Support) is a free OpenCode skill that automates this audit.
+
+Install it in any project:
+
+```bash
+mkdir -p .opencode/skills
+git clone https://github.com/simonplmak-cloud/depression-sensitive-web-content.git \
+  .opencode/skills/depression-sensitive-web-content
+```
+
+Ask OpenCode to audit any file:
+
+```
+Audit src/components/LoginError.tsx for depression-sensitive content issues
+```
+
+Every finding maps to WCAG 2.2, W3C COGA, ISO 9241-110, and ISO/IEC 30071-1 — the four international standards most relevant to cognitive accessibility.
+
+The repository also includes a full SDG & ESG alignment document for teams that need to surface this work in reporting.
+
+---
+
+### Why this matters for open-source
+
+Open-source infrastructure underlies most of the digital interfaces people use. Libraries, frameworks, component systems, design tokens — the defaults set in open-source projects propagate across thousands of products.
+
+When error handling patterns in a component library default to blame language, that pattern ships everywhere the library ships.
+
+Open-source maintainers have disproportionate leverage over the cognitive accessibility of the web. DS-WCS gives that community a concrete, standards-backed tool for exercising that leverage responsibly.
+
+---
+
+### Contribute
+
+DS-WCS is looking for contributors from accessibility, UX writing, healthcare tech, financial services, and government digital teams. The implementation guide already covers 15 content contexts. The goal is to expand that to 50+ with community input.
+
+- **Star or fork:** github.com/simonplmak-cloud/depression-sensitive-web-content
+- **Add examples:** Edit `resources/implementation-guide.md`, Section A.2
+- **Report gaps:** Open an issue describing a pattern not yet covered
+- **Use it:** Run an audit on your own interfaces and share what you find
+
+The SDGs become concrete when individual practitioners connect their daily work to them. A well-written error message is a small act. Multiplied across millions of interfaces, it is not.

--- a/docs/marketing/directory-submission-template.md
+++ b/docs/marketing/directory-submission-template.md
@@ -1,0 +1,71 @@
+# Directory Submission Template — DS-WCS Skill
+
+Ready-to-use submission text for responsible tech directories, accessibility resource lists, and ESG/SDG platforms. Adapt as needed for each directory's specific form fields.
+
+---
+
+## Standard Submission Block
+
+**Project Name:**
+Depression-Sensitive Web Content Support (DS-WCS)
+
+**Short Description (1 sentence):**
+An open-source OpenCode skill that audits and rewrites web content for cognitive accessibility, mapping every finding to WCAG 2.2, W3C COGA, ISO 9241-110, and ISO/IEC 30071-1.
+
+**Full Description (150 words):**
+DS-WCS is a free, open-source skill for the OpenCode AI coding agent that helps content designers, UX writers, and product teams identify and fix content patterns that create cognitive barriers or emotional distress for users with depression, anxiety, and other conditions affecting executive function.
+
+The skill applies seven evidence-based rewrite principles across error messages, CTAs, empty states, forms, notifications, and onboarding flows. Every recommendation maps to four international standards, providing audit-ready traceability for ESG disclosures, accessibility policies, and inclusive design commitments.
+
+DS-WCS contributes to SDG 3 (mental health and well-being) and SDG 10 (reduced inequalities) and addresses the Social and Governance pillars of ESG frameworks. It includes a 40-item audit checklist, 15 before/after rewrite examples, and a complete standards traceability matrix.
+
+Free to install with one git clone. MIT license.
+
+**URL:**
+https://github.com/simonplmak-cloud/depression-sensitive-web-content
+
+**License:**
+MIT
+
+**Category / Tags:**
+Accessibility, Cognitive Accessibility, Content Design, UX Writing, Mental Health UX, Inclusive Design, ESG Social, SDG 3, SDG 10, Neurodiversity, Responsible Tech, WCAG, W3C COGA, Developer Tools, Open Source
+
+**Target Users:**
+UX writers, content designers, accessibility specialists, product teams, ESG/CSR teams, healthcare and financial services teams
+
+**Standards Alignment:**
+WCAG 2.2, W3C COGA Supplemental Guidance, ISO 9241-110:2006, ISO/IEC 30071-1:2019
+
+**SDG Alignment:**
+SDG 3 (Target 3.4), SDG 8 (Target 8.5), SDG 10 (Target 10.3)
+
+---
+
+## Target Directories
+
+### Accessibility
+
+| Directory | URL | Notes |
+|-----------|-----|-------|
+| The A11Y Project Resources | https://www.a11yproject.com/resources/ | Submit via GitHub PR |
+| WebAIM Resources | https://webaim.org/resources/ | Email submission |
+| Inclusive Design Institute | https://inclusivedesign.ca | Contact form |
+| W3C COGA Community Group | https://www.w3.org/community/coga-community/ | Mailing list post |
+
+### Responsible Tech / ESG
+
+| Directory | URL | Notes |
+|-----------|-----|-------|
+| Responsible Tech Guide | https://responsibletechguide.com | Submission form |
+| Tech for Good Global | https://www.techforgood.global | Directory submission |
+| B Lab Tech for Social Good | https://www.bcorporation.net | Post in B Corp community |
+| GRI Community Forums | https://community.globalreporting.org | Post in Social pillar thread |
+
+### Developer / Open Source
+
+| Directory | URL | Notes |
+|-----------|-----|-------|
+| OpenCode Skills Gallery | https://opencode.ai | If/when skills gallery launches |
+| Awesome Accessibility (GitHub) | https://github.com/brunopulis/awesome-a11y | PR to add under Tools |
+| Product Hunt | https://www.producthunt.com | Launch post |
+| Dev.to | https://dev.to | Technical article with submission |

--- a/docs/marketing/linkedin-content-pack.md
+++ b/docs/marketing/linkedin-content-pack.md
@@ -1,0 +1,173 @@
+# LinkedIn Content Pack — DS-WCS Skill
+
+Five ready-to-post LinkedIn updates. Each is self-contained and can be posted independently. The recommended sequence is Posts 1–3 in weeks 1–2, then Posts 4–5 in weeks 3–5.
+
+---
+
+## Post 1 — Skill Announcement (Week 1)
+
+**Target audience:** ESG practitioners, product teams, accessibility specialists, OpenCode users
+
+```
+We just open-sourced a free tool for product teams building more inclusive digital experiences.
+
+Depression-Sensitive Web Content Support (DS-WCS) is an OpenCode skill that audits and rewrites UI content — error messages, CTAs, forms, empty states — for cognitive accessibility.
+
+Every finding maps to four international standards:
+• WCAG 2.2
+• W3C COGA
+• ISO 9241-110
+• ISO/IEC 30071-1
+
+It advances SDG 3 (mental health and well-being) and SDG 10 (reduced inequalities) — and contributes directly to the Social pillar of ESG frameworks.
+
+One git clone. Works inside OpenCode. Zero cost.
+
+→ github.com/simonplmak-cloud/depression-sensitive-web-content
+
+#ESG #SDG #CognitiveAccessibility #InclusiveDesign #ResponsibleTech #WCAG #OpenSource
+```
+
+---
+
+## Post 2 — Before/After Rewrite Examples (Week 1–2)
+
+**Target audience:** UX writers, content designers, product managers
+
+```
+Your error messages may be driving users away — not because of bugs, but because of language.
+
+Here are 3 real rewrites from our open-source DS-WCS content audit framework:
+
+---
+
+BEFORE: "Invalid email! Try again."
+AFTER: "Email format not recognized. Please use this format: name@domain.com"
+
+---
+
+BEFORE: "You broke something. This page doesn't exist."
+AFTER: "Page not found. Check the URL for typos, or return to the homepage."
+
+---
+
+BEFORE: "Application rejected. Better luck next time!"
+AFTER: "Application status: Not selected. You can apply for other open positions that match your skills."
+
+---
+
+The difference isn't just tone. Research shows shame-inducing language activates the brain's threat response, impairing executive function and triggering task abandonment — particularly for users experiencing depression.
+
+280 million people globally live with depression (WHO). They use your product.
+
+Full rewrite library (15 before/after examples, 40-item audit checklist):
+→ github.com/simonplmak-cloud/depression-sensitive-web-content
+
+#UXWriting #ContentDesign #CognitiveAccessibility #InclusiveDesign #ESG #MentalHealthUX
+```
+
+---
+
+## Post 3 — ESG Social Pillar Angle (Week 2)
+
+**Target audience:** ESG/CSR teams, sustainability leads, responsible tech advocates
+
+```
+Most ESG Social disclosures focus on supply chain, workforce diversity, and community investment.
+
+Very few mention cognitive accessibility in digital products.
+
+That's a gap worth closing.
+
+Depression affects 280 million people globally. Cognitive differences — including those caused by anxiety, ADHD, and executive function impairments — are among the most common disabilities in the world.
+
+When your digital interfaces use blame language, urgency pressure, or memory-dependent instructions, you are systematically excluding a significant portion of your users. That is a Social pillar issue.
+
+The Depression-Sensitive Web Content Support (DS-WCS) framework gives product teams:
+• A 40-item content audit checklist
+• 15 before/after rewrite examples
+• Standards traceability to WCAG 2.2, W3C COGA, ISO 9241-110, and ISO/IEC 30071-1
+• Alignment documentation for GRI, SASB, B Corp, and UN Global Compact reporting
+
+It's open source, free to use, and maps directly to SDG 3 and SDG 10.
+
+SDG & ESG alignment documentation:
+→ github.com/simonplmak-cloud/depression-sensitive-web-content/blob/main/docs/sdg-esg-alignment.md
+
+#ESG #SocialImpact #SDG3 #SDG10 #DEI #Neurodiversity #DigitalEquity #ResponsibleTech
+```
+
+---
+
+## Post 4 — Standards Traceability as ESG Evidence (Week 3–4)
+
+**Target audience:** ESG reporting teams, governance leads, compliance officers
+
+```
+"We are committed to inclusive design."
+
+That sentence appears in a lot of ESG reports.
+
+What's rarer: audit-ready evidence of what that commitment looks like in practice.
+
+The DS-WCS skill generates findings in this format:
+
+---
+Finding: Blame language in error message
+File: src/components/checkout/ErrorState.tsx:42
+Original: "You entered invalid card details."
+Standards: WCAG 3.3.1 (Error Identification) | COGA Objective 2 | ISO 9241-110 Clause 5.7 | ISO/IEC 30071-1 Clause 9.1
+---
+
+Every finding is traceable to a specific clause in a specific standard.
+
+That's the kind of documentation that belongs in an ESG Social disclosure — not just a statement of intent, but a record of what was found, what was fixed, and which international standards guided the decision.
+
+DS-WCS is free, open source, and requires one git clone to install.
+
+→ github.com/simonplmak-cloud/depression-sensitive-web-content
+
+#ESG #Governance #AccessibilityAudit #WCAG #ContentDesign #InclusiveDesign #SDG10
+```
+
+---
+
+## Post 5 — Contributor & Fork Invitation (Week 4–5)
+
+**Target audience:** Accessibility community, UX writers, responsible tech practitioners, open-source contributors
+
+```
+DS-WCS is an open-source OpenCode skill for depression-sensitive content design.
+
+It already covers:
+• 7 core rewrite principles
+• 15 before/after examples across healthcare, finance, e-commerce, and government contexts
+• 40+ audit checklist items
+• Full standards traceability to WCAG 2.2, W3C COGA, ISO 9241-110, and ISO/IEC 30071-1
+
+We are looking for contributors from the accessibility, UX writing, and responsible tech communities to help expand it.
+
+If you work in:
+• Content design or UX writing
+• Accessibility consulting
+• Mental health technology
+• Healthcare or financial services UX
+• ESG / responsible product development
+
+...your domain knowledge belongs in this resource.
+
+Fork instructions, contribution guidelines, and the full implementation guide are in the repository.
+
+→ github.com/simonplmak-cloud/depression-sensitive-web-content
+
+#OpenSource #AccessibilityContributions #UXWriting #CognitiveAccessibility #ResponsibleTech #ESG #SDG #InclusiveDesign
+```
+
+---
+
+## Posting Notes
+
+- Recommended cadence: one post every 5–7 days
+- Tag 2–3 relevant people or organizations in each post where appropriate (accessibility leads, ESG practitioners, OpenCode community)
+- Engage with comments within the first 60 minutes of posting to boost algorithmic reach
+- Posts 2 and 4 perform well as carousel formats — the before/after structure translates directly to slides

--- a/docs/marketing/reddit-post-pack.md
+++ b/docs/marketing/reddit-post-pack.md
@@ -1,0 +1,157 @@
+# Reddit Post Pack — DS-WCS Skill
+
+Three posts, one per subreddit. Each is written community-first — the value (resource, examples, discussion) leads; the project link is secondary. Reddit penalises posts that read as self-promotion. These are framed as contributions to the community.
+
+---
+
+## Post 1 — r/accessibility
+
+**Subreddit:** r/accessibility
+**Post type:** Text post (no link post — text posts perform better in this sub)
+**Title:** Free cognitive accessibility audit checklist for UI content — 40 items, maps to WCAG 2.2 and W3C COGA
+
+---
+
+**Body:**
+
+I put together an open-source audit framework for cognitive accessibility in UI content — specifically for the content layer that most accessibility audits skip: error messages, CTAs, empty states, form instructions, notifications, and onboarding flows.
+
+It covers 40+ audit items across those categories, with severity ratings (HIGH/MEDIUM/LOW), remediation guidance, and full traceability to WCAG 2.2, W3C COGA, ISO 9241-110, and ISO/IEC 30071-1 for every finding.
+
+A few examples of what it catches:
+
+**HIGH severity:**
+- Blame language in error messages ("You entered invalid data" → attribute to format, not user)
+- Missing recovery paths ("Error occurred" with no next step)
+- Placeholder text used as the only label (disappears on focus, violates WCAG 3.3.2)
+- Conditional fields that appear without warning
+
+**MEDIUM severity:**
+- Generic button labels ("Submit", "OK", "Go") — violates WCAG 2.4.6
+- Password requirements hidden until after failure
+- Multi-step forms with no progress indicator
+- Memory-dependent form instructions ("Call us for your policy number")
+
+**LOW severity:**
+- Exclamation points in error states
+- Excessive enthusiasm in confirmations ("Congratulations!!! You did it!!!")
+
+The checklist is in a GitHub repo along with a 15-example before/after rewrite library and a full standards traceability matrix.
+
+Would be interested in feedback from practitioners on gaps — particularly for native app contexts, voice interfaces, or domains I haven't covered well (e.g., education platforms, government services).
+
+→ https://github.com/simonplmak-cloud/depression-sensitive-web-content
+
+---
+
+## Post 2 — r/UXDesign
+
+**Subreddit:** r/UXDesign
+**Post type:** Text post
+**Title:** 15 before/after UI content rewrites for cognitive accessibility — looking for critique
+
+---
+
+**Body:**
+
+I've been building an open-source audit framework for cognitive accessibility in UI content and wanted to share the rewrite library here for critique. These are the patterns I see most frequently in audits — interested to know if practitioners here agree with the rewrites or would approach them differently.
+
+Here are 5 of the 15 examples:
+
+---
+
+**Error message — e-commerce checkout:**
+Before: "Invalid email! Try again."
+After: "Email format not recognised. Please use this format: name@domain.com"
+
+Rationale: Removes blame attribution, removes exclamation point, provides concrete recovery path and format example.
+
+---
+
+**Empty state — wellness app:**
+Before: "No activities logged. You should track your mood daily to see your progress over time."
+After: "When you log activities, they'll appear here. Optional: track your mood to identify patterns in your energy and wellbeing."
+
+Rationale: Removes "should" (obligation language), removes "progress" (implies current failure), emphasises optionality.
+
+---
+
+**CTA — account signup:**
+Before: "Sign up now!"
+After: "Create your account (takes about 2 minutes)"
+
+Rationale: Self-descriptive outcome, time expectation reduces uncertainty, no urgency pressure.
+
+---
+
+**Session timeout — general web:**
+Before: "WARNING: Your session expires in 60 seconds! Save now or lose all your changes!"
+After: "Your session will expire in 5 minutes due to inactivity. Save your work to continue."
+
+Rationale: Extended warning window, removed caps and exclamation points, removed threat language, single calm action.
+
+---
+
+**Job application rejection — job platform:**
+Before: "Application rejected. Better luck next time!"
+After: "Application status: Not selected. You can apply for other open positions that match your skills."
+
+Rationale: Removed "rejected" framing, removed "luck" (implies random outcome), provided constructive next step.
+
+---
+
+All 15 rewrites map to WCAG 2.2, W3C COGA, ISO 9241-110, and ISO/IEC 30071-1 — so the rationale isn't subjective, it's grounded in the relevant standards.
+
+The full library, audit checklist, and standards traceability matrix are in the repo if anyone wants to dig in:
+→ https://github.com/simonplmak-cloud/depression-sensitive-web-content
+
+Happy to discuss any of the rewrites — particularly cases where the before version might be appropriate in certain contexts, or where the after version introduces new problems.
+
+---
+
+## Post 3 — r/opensource
+
+**Subreddit:** r/opensource
+**Post type:** Text post
+**Title:** DS-WCS — open-source OpenCode skill for cognitive accessibility audits in UI content [MIT]
+
+---
+
+**Body:**
+
+**What it is:**
+An OpenCode agent skill that audits and rewrites UI content for cognitive accessibility. It targets the content layer — error messages, CTAs, form instructions, empty states, notifications — that most accessibility tools don't cover.
+
+**How it works:**
+Install with one `git clone` into your `.opencode/skills/` directory. Ask OpenCode to audit any file or content snippet. It returns prioritised findings with standards citations (WCAG 2.2, W3C COGA, ISO 9241-110, ISO/IEC 30071-1) and before/after rewrite recommendations.
+
+```bash
+mkdir -p .opencode/skills
+git clone https://github.com/simonplmak-cloud/depression-sensitive-web-content.git \
+  .opencode/skills/depression-sensitive-web-content
+```
+
+Then in OpenCode:
+```
+Audit src/components/ErrorState.tsx for depression-sensitive content issues
+```
+
+**What's in the repo:**
+- `SKILL.md` — main skill definition loaded by OpenCode
+- `resources/implementation-guide.md` — 7 core rewrite principles, 15 before/after examples, 40-item audit checklist, full standards traceability matrix
+- `AGENTS.md` — agent context and auto-invocation triggers
+- `docs/` — SDG/ESG alignment documentation, fork instructions
+
+**License:** MIT
+
+**Looking for contributors:**
+The implementation guide currently covers general web, e-commerce, healthcare, financial services, and job platform contexts. Would like to expand to:
+- Education platforms
+- Government / public sector services
+- Native mobile (iOS/Android content patterns)
+- Voice interfaces
+- Additional language/localization examples
+
+If you work in any of these domains and want to add before/after examples or audit checklist items, the contribution guide is in `.github/CONTRIBUTING.md`.
+
+→ https://github.com/simonplmak-cloud/depression-sensitive-web-content

--- a/docs/marketing/x-twitter-content-pack.md
+++ b/docs/marketing/x-twitter-content-pack.md
@@ -1,0 +1,301 @@
+# X / Twitter Content Pack — DS-WCS Skill
+
+Four threads, written tweet-by-tweet. Each tweet is numbered. The first tweet is the hook — it must stand alone if the thread is not expanded. End each thread by replying to tweet 1 with tweet 2, then continuing in sequence.
+
+Character limit: 280 per tweet. All tweets below are within limit.
+
+---
+
+## Thread 1 — "7 error messages that silently lose users"
+
+**Target audience:** Developers, UX designers, product managers
+**Best posting time:** Tuesday or Wednesday, 9–11am
+
+---
+
+**Tweet 1 (hook):**
+7 error messages that silently lose users — and what to write instead.
+
+(A thread on cognitive accessibility and why your content is doing more damage than your bugs.)
+
+---
+
+**Tweet 2:**
+1/ "Invalid email! Try again."
+
+The exclamation point raises emotional arousal. "Invalid" attributes failure to the user. There's no recovery path.
+
+Rewrite: "Email format not recognized. Use this format: name@domain.com"
+
+---
+
+**Tweet 3:**
+2/ "You broke something. This page doesn't exist."
+
+Second-person blame. Research shows shame-inducing language activates the threat response, impairing problem-solving — especially for users with depression.
+
+Rewrite: "Page not found. Check the URL, or return to the homepage."
+
+---
+
+**Tweet 4:**
+3/ "Fatal error! Contact administrator immediately!"
+
+Two exclamation points. "Fatal" triggers alarm with no useful information. No timeframe, no next step.
+
+Rewrite: "System error (500). We've been notified. Try again in 5 minutes or contact support@example.com"
+
+---
+
+**Tweet 5:**
+4/ "Wrong password."
+
+No recovery path. No format hint. No alternative.
+
+Rewrite: "Password not recognised for this email. Reset your password or try a different email address."
+
+---
+
+**Tweet 6:**
+5/ "Application rejected. Better luck next time!"
+
+Dismissive framing. "Luck" implies the outcome was random, not merit-based.
+
+Rewrite: "Application status: Not selected. Other open positions that match your skills are available to view."
+
+---
+
+**Tweet 7:**
+6/ "WARNING: Your session expires in 60 seconds! Save now or lose all your changes!"
+
+Threat language. 60-second window. Caps for alarm.
+
+Rewrite: "Your session will expire in 5 minutes due to inactivity. Save your work to continue."
+
+---
+
+**Tweet 8:**
+7/ "No activities logged. You should track your mood daily to see your progress over time."
+
+"Should" = obligation. "Progress" implies current failure.
+
+Rewrite: "When you log activities, they'll appear here. Optional: track your mood to identify patterns."
+
+---
+
+**Tweet 9 (CTA):**
+All 7 rewrites are from the DS-WCS open-source skill — a free cognitive accessibility audit framework for OpenCode.
+
+15 before/after examples. 40-item checklist. Maps to WCAG 2.2, W3C COGA, ISO 9241-110.
+
+→ github.com/simonplmak-cloud/depression-sensitive-web-content
+
+#CognitiveAccessibility #UXWriting #A11y #InclusiveDesign
+
+---
+
+---
+
+## Thread 2 — "SDG 3 and your error messages"
+
+**Target audience:** ESG practitioners, responsible tech, product leaders
+**Best posting time:** Monday or Thursday, 8–10am
+
+---
+
+**Tweet 1 (hook):**
+SDG 3 is about promoting mental health and well-being.
+
+Most product teams think that means building mental health apps.
+
+It also means not writing error messages that shame people.
+
+A thread.
+
+---
+
+**Tweet 2:**
+280 million people globally live with depression (WHO, 2023).
+
+Depression impairs:
+- Working memory
+- Executive function
+- Processing speed
+- Decision-making
+
+These users are on your platform right now.
+
+---
+
+**Tweet 3:**
+When your interface says "You entered invalid data" — it activates the brain's threat response.
+
+For users without depression, that's friction.
+For users with depression, that can be task abandonment.
+
+The cognitive load is not symmetrical.
+
+---
+
+**Tweet 4:**
+SDG 3 Target 3.4: "Promote mental health and well-being."
+
+SDG 10 Target 10.3: Eliminate discrimination by disability status.
+
+Cognitive accessibility in digital interfaces is a direct contribution to both.
+
+This is not a stretch. It's the actual standard.
+
+---
+
+**Tweet 5:**
+We built an open-source tool that maps content design decisions to these SDG targets — and to WCAG 2.2, W3C COGA, ISO 9241-110, and ISO/IEC 30071-1.
+
+Every finding has a standard citation. Every rewrite has a rationale.
+
+It's a UX tool. Not a clinical one.
+
+---
+
+**Tweet 6:**
+It's called DS-WCS — Depression-Sensitive Web Content Support.
+
+Free. Open source. One git clone to install. Works inside OpenCode.
+
+Full SDG & ESG alignment doc included for reporting teams.
+
+→ github.com/simonplmak-cloud/depression-sensitive-web-content
+
+#SDG3 #SDG10 #ESG #ResponsibleTech #CognitiveAccessibility
+
+---
+
+---
+
+## Thread 3 — "What the S in ESG misses"
+
+**Target audience:** ESG practitioners, CSR teams, sustainability professionals on X
+**Best posting time:** Wednesday, 9–11am
+
+---
+
+**Tweet 1 (hook):**
+The S in ESG gets discussed a lot.
+
+Supply chain. Workforce diversity. Community investment.
+
+One thing almost never mentioned: what your digital product does to users with cognitive impairments.
+
+Thread.
+
+---
+
+**Tweet 2:**
+Cognitive disabilities — including depression, anxiety, ADHD, and executive function differences — are among the most prevalent disabilities globally.
+
+Depression alone affects 1 in 20 people.
+
+Your digital products are the interface between your organisation and those people.
+
+---
+
+**Tweet 3:**
+When that interface uses:
+- Blame language in errors
+- Urgency pressure in CTAs
+- Memory-dependent form instructions
+- Dismissive empty states
+
+...you are systematically excluding a significant user population.
+
+That's a Social pillar issue.
+
+---
+
+**Tweet 4:**
+The good news: this is fixable at the content layer.
+
+No engineering sprint. No design system overhaul. Just rewriting the words.
+
+And there are international standards that tell you exactly what to change and why.
+
+---
+
+**Tweet 5:**
+WCAG 2.2, W3C COGA, ISO 9241-110, ISO/IEC 30071-1.
+
+These standards cover cognitive accessibility in detail. Most ESG Social disclosures never reference them.
+
+They should.
+
+---
+
+**Tweet 6:**
+We built an open-source audit framework that:
+- Flags cognitive accessibility issues in UI content
+- Maps every finding to the relevant standard
+- Provides before/after rewrites
+- Generates ESG-ready documentation
+
+Free. MIT license.
+
+→ github.com/simonplmak-cloud/depression-sensitive-web-content
+
+#ESG #SocialPillar #DEI #Neurodiversity #DigitalEquity #CognitiveAccessibility
+
+---
+
+---
+
+## Thread 4 — Recap / Best-of (Week 6)
+
+**Target audience:** Broad — followers who missed earlier threads
+**Best posting time:** Friday, 12–2pm
+
+---
+
+**Tweet 1 (hook):**
+A month ago I posted about cognitive accessibility in UI content.
+
+Here's what resonated, what I learned, and the tool that started it all.
+
+[Recap thread]
+
+---
+
+**Tweet 2:**
+The post that got the most engagement: 7 error messages that silently lose users.
+
+The one that surprised people most: that SDG 3 (mental health) applies directly to how you write form validation.
+
+---
+
+**Tweet 3:**
+The most common response I got: "I never thought about error messages as an accessibility issue."
+
+That's exactly the gap DS-WCS addresses.
+
+It's not about screen readers or colour contrast. It's about the emotional and cognitive impact of words.
+
+---
+
+**Tweet 4:**
+What DS-WCS actually does:
+
+- Audits UI content for shame/blame language, urgency pressure, and cognitive load
+- Maps findings to WCAG 2.2, W3C COGA, ISO 9241-110, ISO/IEC 30071-1
+- Provides 15 before/after rewrites
+- Generates ESG-ready audit documentation
+
+Free. Open source. Works in OpenCode.
+
+---
+
+**Tweet 5:**
+If you're a UX writer, content designer, or accessibility practitioner — fork it, use it, add examples.
+
+If you're on an ESG or CSR team — the SDG & ESG alignment doc is ready to drop into a disclosure.
+
+→ github.com/simonplmak-cloud/depression-sensitive-web-content
+
+#CognitiveAccessibility #ESG #SDG #UXWriting #A11y #OpenSource #InclusiveDesign

--- a/site/index.html
+++ b/site/index.html
@@ -4,16 +4,16 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#0f766e" />
-    <title>Humanity4AI — Humane AI skills for real agents</title>
+    <title>Humanity4AI — 9 Humanity Skills for AI Agents</title>
     <meta
       name="description"
-      content="Open, community-driven humanity skills for AI agents with MCP contracts and evaluation gates."
+      content="9 humanity skills for AI agents — crisis detection, WCAG audits, empathy, cultural sensitivity, and more. MCP + npm."
     />
-    <meta name="keywords" content="humane AI, MCP skills, accessibility, WCAG, empathy, inclusive design, AI ethics, agent tools, content safety, mental health" />
+    <meta name="keywords" content="humane AI, MCP skills, accessibility, WCAG, empathy, inclusive design, AI ethics, agent tools, content safety, mental health, crisis detection, cultural sensitivity, neurodiversity, cognitive accessibility, age-inclusive design, de-escalation, safe content, supportive reply" />
     <meta name="author" content="Humanity4AI / Ascent Partners Foundation" />
     <!-- Open Graph -->
-    <meta property="og:title" content="Humanity4AI — Humane AI skills for real agents" />
-    <meta property="og:description" content="Open skill packs with explicit safety boundaries, MCP action contracts, and quality gates for OpenCode, Claude Code, Copilot, Manus AI, and more." />
+    <meta property="og:title" content="Humanity4AI — 9 Humanity Skills for AI Agents" />
+    <meta property="og:description" content="9 humanity skills for AI agents — crisis detection, WCAG audits, empathy, cultural sensitivity, and more. MCP + npm." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://humanity4ai.github.io/project_human/" />
     <meta property="og:image" content="https://humanity4ai.github.io/project_human/assets/hero-architecture.svg" />
@@ -22,12 +22,9 @@
     <meta property="og:image:height" content="630" />
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Humanity4AI — Humane AI skills for real agents" />
-    <meta name="twitter:description" content="Open skill packs with explicit safety boundaries, MCP contracts, and evaluation gates." />
+    <meta name="twitter:title" content="Humanity4AI — 9 Humanity Skills for AI Agents" />
+    <meta name="twitter:description" content="9 humanity skills for AI agents — crisis detection, WCAG audits, empathy, cultural sensitivity, and more." />
     <meta name="twitter:image" content="https://humanity4ai.github.io/project_human/assets/hero-architecture.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
     <!-- Canonical -->
     <link rel="canonical" href="https://humanity4ai.github.io/project_human/" />
     <!-- Favicon -->
@@ -44,7 +41,7 @@
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Humanity4AI",
-      "description": "Open skill system for humane AI — 9 reusable specifications with MCP contracts and evaluation gates.",
+      "description": "9 humanity skills for AI agents — crisis detection, WCAG audits, empathy, cultural sensitivity, and more. MCP + npm.",
       "url": "https://humanity4ai.github.io/project_human/",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "Cross-platform",
@@ -62,14 +59,13 @@
     <header class="hero" role="banner">
       <div class="hero-inner">
         <p class="kicker">Humanity4AI <span class="platform-badge">Windows · macOS · Linux · Android · iOS</span></p>
-        <h1>Humane AI skills, structured for real agents</h1>
+        <h1>9 Humanity Skills for AI Agents</h1>
         <p class="lead">
-          Open skill packs with explicit safety boundaries, MCP action contracts, and quality gates for
-          OpenCode, Claude Code, Copilot, Manus AI, OpenClaw, and more.
+          Crisis detection, WCAG audits, empathy, cultural sensitivity, and more — open skill packs with explicit safety boundaries for OpenCode, Claude Code, Copilot, Manus AI, and beyond.
         </p>
         <div class="cta-row">
-          <a class="btn primary" href="https://github.com/humanity4ai/project_human">View GitHub</a>
-          <a class="btn" href="https://github.com/humanity4ai/project_human/releases">Latest Release</a>
+          <a class="btn primary" href="https://github.com/humanity4ai/project_human">⭐ View on GitHub</a>
+          <a class="btn" href="https://www.npmjs.com/package/@humanity4ai/mcp-servers">npm Package</a>
           <a class="btn" href="https://github.com/humanity4ai/project_human/issues">Contribute</a>
         </div>
       </div>
@@ -77,16 +73,64 @@
     </header>
 
     <main id="main-content" class="content">
-      <section class="quickstart" aria-label="Get started in 3 steps">
-        <h2>Get Started in 3 Steps</h2>
-        <p>Windows, macOS, or Linux — Node.js ≥ 20 + pnpm ≥ 10 required. Or use the one-line installer: <code>bash install.sh</code></p>
-        <pre><code># Step 1 — Install &amp; Verify
-git clone https://github.com/humanity4ai/project_human.git
-cd project_human &amp;&amp; pnpm install &amp;&amp; pnpm check &amp;&amp; pnpm evals
+      <section class="skills-grid" aria-label="9 humanity skills">
+        <h2>Skills at a Glance</h2>
+        <div class="grid three">
+          <article class="card">
+            <h3>🛡️ Supportive Reply</h3>
+            <p>Detects crisis signals, generates supportive responses with escalation guidance.</p>
+            <span class="tag">Emotional Safety</span>
+          </article>
+          <article class="card">
+            <h3>📝 Safe Content Rewriter</h3>
+            <p>Audits and rewrites text to remove harmful, stigmatising, or triggering patterns.</p>
+            <span class="tag">Emotional Safety</span>
+          </article>
+          <article class="card">
+            <h3>♿ Accessibility Audit</h3>
+            <p>Scores pages against all 86 WCAG 2.2 success criteria (A/AA/AAA).</p>
+            <span class="tag">Accessibility</span>
+          </article>
+          <article class="card">
+            <h3>🧠 Cognitive Accessibility</h3>
+            <p>Audits content for reading level, structure, and cognitive load.</p>
+            <span class="tag">Cognitive Support</span>
+          </article>
+          <article class="card">
+            <h3>🌍 Cultural Context Check</h3>
+            <p>Flags cultural sensitivity issues for a given audience and region.</p>
+            <span class="tag">Cultural Context</span>
+          </article>
+          <article class="card">
+            <h3>🔥 De-escalation Plan</h3>
+            <p>Generates structured de-escalation plans calibrated to conflict intensity.</p>
+            <span class="tag">Conflict Navigation</span>
+          </article>
+          <article class="card">
+            <h3>💬 Empathetic Reframe</h3>
+            <p>Reframes messages with genuine empathy, catching hollow empathy patterns.</p>
+            <span class="tag">Communication</span>
+          </article>
+          <article class="card">
+            <h3>🧩 Neurodiversity Design</h3>
+            <p>Audits UIs for ADHD, autism, dyslexia, and sensory sensitivity.</p>
+            <span class="tag">Neurodiversity</span>
+          </article>
+          <article class="card">
+            <h3>👶 Age-Inclusive Design</h3>
+            <p>Audits user flows for age barriers across children, adults, and older users.</p>
+            <span class="tag">Age Inclusion</span>
+          </article>
+        </div>
+      </section>
 
-# Step 2 — Start the MCP server
-pnpm start</code></pre>
-        <p><strong>Step 3 — Configure your agent</strong> by adding this to your MCP client config:</p>
+      <section class="quickstart" aria-label="Get started">
+        <h2>Quick Start</h2>
+        <p>One command to clone, install, verify, and start:</p>
+        <pre><code>git clone https://github.com/humanity4ai/project_human.git &amp;&amp; cd project_human &amp;&amp; pnpm install &amp;&amp; pnpm check &amp;&amp; pnpm evals &amp;&amp; pnpm start</code></pre>
+        <p>Or use the npm package directly:</p>
+        <pre><code>npx @humanity4ai/mcp-servers</code></pre>
+        <p><strong>Configure your agent</strong> by adding this to your MCP client config:</p>
         <pre><code>{
   "mcpServers": {
     "humanity4ai": {
@@ -96,15 +140,14 @@ pnpm start</code></pre>
     }
   }
 }</code></pre>
-        <p>        All 9 skills are now available via <code>tools/list</code> and <code>tools/call</code>.</p>
+        <p>All 9 skills are now available via <code>tools/list</code> and <code>tools/call</code>.</p>
+        <p><strong>Docker:</strong> <code>docker compose up</code> | <strong>Prerequisites:</strong> Node.js ≥ 20, pnpm ≥ 10</p>
       </section>
 
       <section class="manifesto" aria-label="Manifesto">
-        <h2>The Soul of New Machines: Last Epigone</h2>
+        <h2>Why Humanity4AI?</h2>
         <p>
-          Humanity4AI argues that intelligence without humanity is not progress. AI systems that influence human
-          outcomes must respect dignity, communicate uncertainty honestly, and escalate to qualified human support
-          when risk exceeds model competence.
+          AI agents are everywhere — but they're not always humane. Humanity4AI gives agents reusable, tested skills for the moments that matter: detecting a user in crisis, auditing content for accessibility, catching harmful language patterns, and more. Every skill includes explicit safety boundaries, uncertainty disclosure, and evaluation gates.
         </p>
         <div class="cta-row">
           <a class="btn primary" href="https://github.com/humanity4ai/project_human/blob/main/docs/manifesto.md">Read Manifesto</a>
@@ -113,34 +156,8 @@ pnpm start</code></pre>
         </div>
       </section>
 
-      <section aria-label="What ships now">
-        <h2>What ships now</h2>
-        <div class="grid three">
-          <article class="card">
-            <h3>9 Skill Packs</h3>
-            <p>Accessibility, emotional safety, inclusive design, and communication patterns.</p>
-          </article>
-          <article class="card">
-            <h3>MCP Contracts</h3>
-            <p>Action IDs, JSON schemas, and runtime stubs for integration across agent platforms.</p>
-          </article>
-          <article class="card">
-            <h3>Eval Gates</h3>
-            <p>Automated baseline checks for skill completeness and contract consistency.</p>
-          </article>
-        </div>
-      </section>
-
-      <section aria-label="Quick commands">
-        <h2>Quick commands</h2>
-        <pre><code>pnpm install
-pnpm check
-pnpm evals
-pnpm start</code></pre>
-      </section>
-
       <section aria-label="First contribution">
-        <h2>First contribution</h2>
+        <h2>First Contribution</h2>
         <p>Pick a starter task and open a PR in under 10 minutes.</p>
         <ul>
           <li><a href="https://github.com/humanity4ai/project_human/issues?q=is%3Aopen+label%3A%22good+first+issue%22">Good First Issues</a> — entry points for new contributors</li>
@@ -151,9 +168,12 @@ pnpm start</code></pre>
     </main>
 
     <footer class="site-footer" role="contentinfo">
-      <p>MIT License &bull; Copyright &copy; 2026 Ascent Partners Foundation &bull;
-        <a href="https://github.com/humanity4ai/project_human" rel="noopener noreferrer">GitHub</a> &bull;
-        <a href="https://github.com/humanity4ai/project_human/blob/main/docs/GOVERNANCE.md" rel="noopener noreferrer">Governance</a> &bull;
+      <p>
+        ⭐ <a href="https://github.com/humanity4ai/project_human">Star on GitHub</a> ·
+        <a href="https://twitter.com/intent/tweet?text=Humanity4AI%20%E2%80%94%209%20humanity%20skills%20for%20AI%20agents%20%F0%9F%A4%9D%0A%0ACrisis%20detection%2C%20WCAG%20audits%2C%20empathy%2C%20cultural%20sensitivity%2C%20and%20more.%0A%0Ahttps%3A%2F%2Fgithub.com%2Fhumanity4ai%2Fproject_human">Share on X</a> ·
+        MIT License · Copyright © 2026 Ascent Partners Foundation ·
+        <a href="https://github.com/humanity4ai/project_human" rel="noopener noreferrer">GitHub</a> ·
+        <a href="https://github.com/humanity4ai/project_human/blob/main/docs/GOVERNANCE.md" rel="noopener noreferrer">Governance</a> ·
         <a href="https://github.com/humanity4ai/project_human/blob/main/SECURITY.md" rel="noopener noreferrer">Security</a>
       </p>
     </footer>

--- a/site/styles.css
+++ b/site/styles.css
@@ -183,6 +183,33 @@ h1 {
   padding: 1rem;
 }
 
+.card h3 {
+  margin-top: 0;
+}
+
+.card p {
+  color: var(--muted);
+}
+
+.tag {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--accent);
+  background: #f0fdfa;
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  padding: 0.15rem 0.6rem;
+}
+
+@media (prefers-contrast: more) {
+  .tag {
+    color: #000000;
+    border-color: #000000;
+    background: #ffffff;
+  }
+}
+
 pre {
   background: #0b1220;
   color: #d1fae5;

--- a/skills/accessibility/SKILL.md
+++ b/skills/accessibility/SKILL.md
@@ -37,3 +37,22 @@ Two analysis engines:
 - Level A: 31 criteria (18 automatable, 4 partial)
 - Level AA: 55 criteria cumulative (31 automatable, 8 partial)
 - Level AAA: 86 criteria cumulative (41 automatable, 15 partial)
+
+## References
+
+Implementation guidance and enterprise patterns (merged from `wcag-aaa-web-design`):
+
+- `references/wcag-aaa-checklist.md` — all 87 WCAG 2.2 criteria with implementation guidance and AAA design implications
+- `references/corporate-design-system.md` — AAA-verified color palette with precomputed contrast ratios, type scale, BEM architecture
+- `references/aria-patterns.md` — ARIA widget patterns (modals, tabs, accordions, focus traps)
+- `references/form-patterns.md` — accessible form design and validation
+- `references/security-error-handling.md` — OWASP-aligned secure error handling (CSP, CSRF, output encoding)
+- `references/application-states.md` — loading, empty, and error state patterns
+- `references/data-presentation.md` — accessible data table and density patterns
+- `references/navigation-patterns.md` — sidebar, breadcrumb, and wayfinding patterns
+- `references/responsive-breakpoints.md` — mobile-first breakpoint system
+- `references/corporate-ux-patterns.md` — enterprise UX conventions
+
+## Templates
+
+AAA-verified starter templates in `templates/`: design tokens with precomputed 7:1 contrast palette (`tokens.css`), BEM component library (`components.css`), semantic HTML partials, and defensive vanilla JS (`main.js`). A standalone contrast checker with auto-suggestion engine is included as `templates/check_contrast.py` (stdlib-only Python; can audit `--color-*` tokens directly from `tokens.css`).

--- a/skills/accessibility/references/application-states.md
+++ b/skills/accessibility/references/application-states.md
@@ -1,0 +1,103 @@
+# Application State Patterns
+
+## Table of Contents
+
+1. [Loading States](#1-loading-states)
+2. [Empty States](#2-empty-states)
+3. [Error States](#3-error-states)
+
+---
+
+This document provides patterns for handling common application states: loading, empty, and error. These states are critical for a good user experience, as they provide feedback, prevent confusion, and guide the user.
+
+## 1. Loading States
+
+Loading states inform the user that the system is working and content is being fetched. They reduce uncertainty and can make the application feel faster.
+
+### Pattern: Skeleton Screens
+
+For initial page or component loads, **skeleton screens** are the preferred pattern over generic spinners. A skeleton screen is a wireframe-like preview of the UI where content is gradually loaded in.
+
+![Skeleton Screen Example](https://media.nngroup.com/media/editor/2023/05/23/linkedin-skeleton-screen-example.png)
+*(Source: Nielsen Norman Group)*
+
+**Benefits:**
+- Reduces perceived loading time.
+- Informs the user about the expected layout, preventing content from "jumping" as it loads.
+- Provides a more engaging experience than a blank screen with a spinner.
+
+**Implementation:**
+- Create placeholder elements with a subtle background color and a soft, pulsing animation to indicate activity.
+- The skeleton layout should closely match the actual content layout.
+
+```css
+/* Basic Skeleton Animation */
+.skeleton {
+  background-color: var(--color-skeleton);
+  border-radius: var(--radius-md);
+  position: relative;
+  overflow: hidden;
+}
+
+.skeleton::after {
+  content: 																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																							'';
+  display: block;
+  position: absolute;
+  top: 0;
+  left: -150%;
+  height: 100%;
+  width: 150%;
+  background: linear-gradient(to right, transparent 0%, var(--color-skeleton-highlight) 50%, transparent 100%);
+  animation: skeleton-shimmer 1.5s infinite;
+}
+
+@keyframes skeleton-shimmer {
+  0% { left: -150%; }
+  100% { left: 150%; }
+}
+```
+
+---
+
+## 2. Empty States
+
+An empty state occurs when there is no data to display. This is an opportunity to guide the user.
+
+### Types of Empty States
+
+| Type | When to Use | Goal | Example | 
+|---|---|---|---|
+| **No Data (First Use)** | A user's first interaction with a feature. | Educate the user on what the feature does and guide them to their first action. | "You haven't created any projects yet. Click 'New Project' to get started." |
+| **No Results** | A search or filter returns no matches. | Help the user refine their query. Offer suggestions or a way to broaden the search. | "No results found for 'Q4 Report'. Try searching by author or date." |
+| **Action Complete** | A user successfully completes a task, such as clearing all notifications. | Provide positive reinforcement and a clear sense of completion. | "All caught up! You have no new notifications." |
+
+### Anatomy of an Empty State
+
+A good empty state is composed of three parts:
+1.  **Image (Optional)**: A simple, non-distracting illustration that relates to the context.
+2.  **Title**: A clear, concise message. Frame it positively (e.g., "Start by adding data" instead of "You have no data").
+3.  **Body & Action**: A brief explanation of why the state is empty and a clear call-to-action (button or link) to guide the user's next step.
+
+---
+
+## 3. Error States
+
+Error states communicate that something has gone wrong. They must be clear, concise, and actionable. A robust application handles both user input errors and unexpected system failures gracefully.
+
+For full guidance on client-side API error handling and JavaScript error boundaries, see `references/security-error-handling.md`.
+
+### Designing User-Facing Error Messages
+
+Error states communicate that something has gone wrong. They must be clear, concise, and actionable.
+
+### Types of Errors
+
+- **Input Validation Errors**: The user has entered data incorrectly. These should be displayed inline, next to the problematic field.
+- **System Errors**: The system failed to complete an action (e.g., network error, server issue). These are typically displayed in a more prominent notification, like a toast or banner.
+
+### Designing Error Messages
+
+- **Be Specific**: Tell the user exactly what is wrong (e.g., "Email address is invalid" not "Invalid input").
+- **Be Constructive**: Tell the user how to fix the problem (e.g., "Password must be at least 8 characters long").
+- **Don't Blame the User**: Use a neutral, helpful tone.
+- **Use the Right Component**: Use inline text for form validation and toasts/banners for system-level feedback.

--- a/skills/accessibility/references/aria-patterns.md
+++ b/skills/accessibility/references/aria-patterns.md
@@ -1,0 +1,198 @@
+# ARIA Design Patterns for Web Applications
+
+This document provides production-grade, accessible component patterns based on the WAI-ARIA Authoring Practices Guide (APG). Use these patterns for common interactive widgets in web applications to ensure they are operable and understandable for all users, including those using assistive technologies.
+
+## Table of Contents
+
+1.  [Core Concepts](#core-concepts)
+2.  [Modal Dialog](#modal-dialog)
+3.  [Tabs](#tabs)
+4.  [Accordion](#accordion)
+5.  [Alert & Toast](#alert--toast)
+6.  [Menu & Menu Button](#menu--menu-button)
+
+---
+
+## Core Concepts
+
+-   **Keyboard Interaction**: All interactive components MUST be fully operable with a keyboard. The APG provides detailed keyboard interaction models for each pattern (e.g., arrow keys for tabs, Escape key for modals).
+-   **Focus Management**: Scripts MUST manage focus. When a widget opens, focus must move to it. When it closes, focus must return to the element that opened it.
+-   **ARIA Roles, States, and Properties**: Use ARIA attributes to define the role of a component (e.g., `role="dialog"`), its current state (e.g., `aria-expanded="true"`), and its properties (e.g., `aria-labelledby`).
+
+---
+
+## Modal Dialog
+
+A modal dialog is a window overlaid on the primary page content. It requires a user response and **must** trap focus until it is closed.
+
+### ARIA Roles and Attributes
+
+-   **Dialog Container**: `role="dialog"`, `aria-modal="true"`, `aria-labelledby="dialog-title"`, `aria-describedby="dialog-desc"`.
+-   **Title**: An element with an `id` matching the `aria-labelledby` value.
+-   **Description**: An element with an `id` matching the `aria-describedby` value.
+-   **Close Button**: A `<button>` element.
+
+### Keyboard Interaction
+
+-   **Tab**: Moves focus between focusable elements *inside* the dialog. Focus is trapped and cannot leave the modal.
+-   **Shift + Tab**: Moves focus backward *inside* the dialog.
+-   **Escape**: Closes the dialog and returns focus to the button that opened it.
+
+### Example Structure
+
+```html
+<div id="dialog-container" role="dialog" aria-modal="true" aria-labelledby="dialog-title" hidden>
+  <h2 id="dialog-title">Dialog Title</h2>
+  <p id="dialog-desc">Description of the dialog's purpose.</p>
+  <!-- Form elements or other content -->
+  <button id="close-dialog-btn">Close</button>
+</div>
+```
+
+### Focus Management Script
+
+1.  **On Open**: Store the triggering element (e.g., the "Open Dialog" button). Move focus to the first focusable element inside the dialog.
+2.  **While Open**: Implement a focus trap. Listen for `keydown` events. If the user presses `Tab` on the last focusable element, loop focus back to the first. If they press `Shift + Tab` on the first, loop to the last.
+3.  **On Close**: Return focus to the stored triggering element.
+
+---
+
+## Tabs
+
+Tabs are a set of layered sections of content (tab panels) where only one panel is visible at a time.
+
+### ARIA Roles and Attributes
+
+-   **Tab List**: The container for the tabs has `role="tablist"`.
+-   **Tab**: Each tab button has `role="tab"`, `aria-selected="true/false"`, and `aria-controls="panel-id"`.
+-   **Tab Panel**: Each content panel has `role="tabpanel"` and `aria-labelledby="tab-id"`.
+
+### Keyboard Interaction
+
+-   **Tab**: Moves focus into the active tab, then through the tab panel content. When focus is on a tab, the next `Tab` press moves focus to the active tab panel.
+-   **Right Arrow** (in LTR): Moves focus to the next tab in the `tablist`, activating it.
+-   **Left Arrow** (in LTR): Moves focus to the previous tab, activating it.
+-   **Home**: Moves focus to and activates the first tab.
+-   **End**: Moves focus to and activates the last tab.
+
+### Example Structure
+
+```html
+<div class="tabs">
+  <div role="tablist" aria-label="Example Tabs">
+    <button role="tab" aria-selected="true" id="tab-1" aria-controls="panel-1">Tab 1</button>
+    <button role="tab" aria-selected="false" id="tab-2" aria-controls="panel-2" tabindex="-1">Tab 2</button>
+  </div>
+  <div id="panel-1" role="tabpanel" aria-labelledby="tab-1">
+    <p>Content for Panel 1</p>
+  </div>
+  <div id="panel-2" role="tabpanel" aria-labelledby="tab-2" hidden>
+    <p>Content for Panel 2</p>
+  </div>
+</div>
+```
+
+---
+
+## Accordion
+
+An accordion is a vertically stacked set of interactive headings that each contain a title representing a section of content, which can be expanded or collapsed.
+
+### ARIA Roles and Attributes
+
+-   **Accordion Heading**: A `<h2>` (or other appropriate heading level) containing a `<button>`.
+-   **Accordion Button**: The `<button>` has `aria-expanded="true/false"` and `aria-controls="section-id"`.
+-   **Accordion Panel**: The content panel has `role="region"`, an `id` matching the `aria-controls` value, and `aria-labelledby` pointing to the button's `id`.
+
+### Keyboard Interaction
+
+-   **Tab**: Moves focus between accordion headings.
+-   **Enter** or **Space**: Toggles the expansion of the associated panel.
+-   **Down Arrow**: Moves focus to the next accordion heading.
+-   **Up Arrow**: Moves focus to the previous accordion heading.
+-   **Home**: Moves focus to the first accordion heading.
+-   **End**: Moves focus to the last accordion heading.
+
+### Example Structure
+
+```html
+<h3>
+  <button aria-expanded="true" id="accordion-btn-1" aria-controls="accordion-panel-1">
+    Section 1
+  </button>
+</h3>
+<div id="accordion-panel-1" role="region" aria-labelledby="accordion-btn-1">
+  <p>Content for Section 1.</p>
+</div>
+```
+
+---
+
+## Alert & Toast
+
+Alerts are for assertive, time-sensitive information. Toasts are a less intrusive type of alert.
+
+### ARIA Roles and Attributes
+
+-   **Live Region Container**: A container element is always present in the DOM.
+-   **Assertive Alerts**: For critical errors or updates, use `role="alert"` or `aria-live="assertive"`. Screen readers will interrupt whatever they are doing to announce it.
+-   **Polite Toasts**: For status updates or confirmations, use `role="status"` or `aria-live="polite"`. Screen readers will wait for a moment of silence before announcing.
+
+### Implementation
+
+1.  **Create a container** at the end of the `<body>`.
+2.  **Dynamically inject** the alert message into the container using JavaScript.
+3.  The browser and assistive technologies will automatically announce the content when it appears.
+4.  **Do not** move focus to the alert unless it requires user interaction (in which case, use a Modal Dialog).
+
+### Example
+
+```html
+<!-- Polite Live Region for Toasts/Status -->
+<div id="status-announcer" role="status" aria-live="polite" class="sr-only"></div>
+
+<!-- Assertive Live Region for Alerts -->
+<div id="alert-announcer" role="alert" aria-live="assertive" class="sr-only"></div>
+```
+
+```javascript
+// To announce a success message:
+document.getElementById('status-announcer').textContent = 'Your changes have been saved.';
+
+// To announce an error:
+document.getElementById('alert-announcer').textContent = 'Network connection lost.';
+```
+
+---
+
+## Menu & Menu Button
+
+A menu button is a button that opens a dropdown menu of choices.
+
+### ARIA Roles and Attributes
+
+-   **Menu Button**: A `<button>` with `aria-haspopup="true"` and `aria-expanded="true/false"`.
+-   **Menu Container**: A `<ul>` with `role="menu"` and `aria-labelledby` pointing to the menu button's `id`.
+-   **Menu Item**: Each `<li>` has `role="presentation"`. The link or button inside has `role="menuitem"` and `tabindex="-1"`.
+
+### Keyboard Interaction
+
+-   **Enter**, **Space**, **Down Arrow**: Opens the menu and places focus on the first item.
+-   **Down Arrow** (in menu): Moves focus to the next item.
+-   **Up Arrow** (in menu): Moves focus to the previous item.
+-   **Escape**: Closes the menu and returns focus to the menu button.
+-   **Enter** or **Space** (on item): Activates the item and closes the menu.
+
+### Example Structure
+
+```html
+<button id="menu-btn" aria-haspopup="true" aria-expanded="false">Actions</button>
+<ul role="menu" aria-labelledby="menu-btn" hidden>
+  <li role="presentation">
+    <a role="menuitem" tabindex="-1" href="/edit">Edit</a>
+  </li>
+  <li role="presentation">
+    <a role="menuitem" tabindex="-1" href="/delete">Delete</a>
+  </li>
+</ul>
+```

--- a/skills/accessibility/references/corporate-design-system.md
+++ b/skills/accessibility/references/corporate-design-system.md
@@ -1,0 +1,293 @@
+# Corporate Design System
+
+AAA-compliant design tokens and patterns for corporate/formal web applications. All values are provided as CSS custom properties for framework-agnostic use.
+
+## Table of Contents
+
+1. [Color System](#color-system)
+2. [Typography](#typography)
+3. [Spacing and Layout](#spacing-and-layout)
+4. [Component Patterns](#component-patterns)
+5. [Tone and Language](#tone-and-language)
+
+---
+
+## Color System
+
+All color pairings below meet WCAG 2.2 AAA contrast requirements (7:1 for normal text, 4.5:1 for large text).
+
+### Default Corporate Palette
+
+These are sensible defaults. When the user provides brand colors, verify all pairings meet AAA ratios using the `check_contrast.py` script.
+
+| Token | Value | Usage | Contrast vs White | Contrast vs Dark |
+|-------|-------|-------|-------------------|------------------|
+| `--color-primary` | `#1a365d` | Primary actions, headings | 12.6:1 | -- |
+| `--color-primary-dark` | `#0f2440` | Hover states on primary | 15.4:1 | -- |
+| `--color-secondary` | `#2d5016` | Secondary actions, accents | 8.5:1 | -- |
+| `--color-secondary-dark` | `#1e3a0f` | Hover states on secondary | 11.2:1 | -- |
+| `--color-text` | `#1a1a1a` | Body text | 17.2:1 | -- |
+| `--color-text-muted` | `#3d3d3d` | Secondary text | 11.7:1 | -- |
+| `--color-bg` | `#ffffff` | Page background | -- | -- |
+| `--color-bg-alt` | `#f5f5f5` | Alternate sections | -- | -- |
+| `--color-border` | `#4a4a4a` | Borders, dividers | 9.7:1 vs white | -- |
+| `--color-error` | `#8b0000` | Error states | 9.4:1 | -- |
+| `--color-success` | `#1a5c1a` | Success states | 8.1:1 | -- |
+| `--color-warning` | `#6b4c00` | Warning states | 8.9:1 | -- |
+| `--color-focus` | `#0050a0` | Focus indicators | 7.3:1 | -- |
+
+### Contrast Verification Rules
+
+Before using any color pairing, verify:
+- Normal text (<18pt): contrast ratio >= 7:1
+- Large text (>=18pt or >=14pt bold): contrast ratio >= 4.5:1
+- UI components and graphical objects: contrast ratio >= 3:1
+- Focus indicators: contrast ratio >= 3:1 against adjacent colors
+
+Run `python3 scripts/check_contrast.py <fg_hex> <bg_hex>` to verify any pairing.
+
+---
+
+## Typography
+
+### Font Stack
+
+Use system fonts for performance and accessibility. Avoid decorative or thin-weight fonts.
+
+```css
+:root {
+  --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  --font-heading: var(--font-body);
+  --font-mono: "SF Mono", "Fira Code", "Fira Mono", "Roboto Mono",
+    "Courier New", monospace;
+}
+```
+
+### Type Scale
+
+Use `rem` units exclusively. Base size: `1rem` = `16px`.
+
+| Token | Size | Weight | Line-Height | Usage |
+|-------|------|--------|-------------|-------|
+| `--text-xs` | 0.75rem (12px) | 400 | 1.667 | Fine print, captions |
+| `--text-sm` | 0.875rem (14px) | 400 | 1.571 | Secondary text, labels |
+| `--text-base` | 1rem (16px) | 400 | 1.625 | Body text |
+| `--text-lg` | 1.125rem (18px) | 400 | 1.556 | Lead paragraphs |
+| `--text-xl` | 1.25rem (20px) | 600 | 1.5 | H4 |
+| `--text-2xl` | 1.5rem (24px) | 700 | 1.5 | H3 |
+| `--text-3xl` | 1.875rem (30px) | 700 | 1.5 | H2 |
+| `--text-4xl` | 2.25rem (36px) | 700 | 1.5 | H1 |
+
+### AAA Typography Rules (1.4.8)
+
+- Maximum line width: 80 characters (`max-width: 80ch` on text containers)
+- Text alignment: `text-align: start` (never `justify`)
+- Line height: minimum 1.5x font size (`line-height: 1.5` or greater)
+- Paragraph spacing: minimum 2x font size (`margin-block-end` >= 2em)
+- Letter spacing: must tolerate user override to 0.12em without breaking
+- Word spacing: must tolerate user override to 0.16em without breaking
+
+---
+
+## Spacing and Layout
+
+### Spacing Scale
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--space-1` | 0.25rem (4px) | Tight internal spacing |
+| `--space-2` | 0.5rem (8px) | Compact element spacing |
+| `--space-3` | 0.75rem (12px) | Default internal padding |
+| `--space-4` | 1rem (16px) | Standard element spacing |
+| `--space-5` | 1.5rem (24px) | Section internal padding |
+| `--space-6` | 2rem (32px) | Section separation |
+| `--space-8` | 3rem (48px) | Major section separation |
+| `--space-10` | 4rem (64px) | Page-level separation |
+| `--space-12` | 6rem (96px) | Hero/banner spacing |
+
+### Layout Rules
+
+- Use CSS Grid for page-level layout; Flexbox for component-level alignment
+- Maintain consistent gutters: `--space-4` (sm), `--space-5` (md), `--space-6` (lg)
+- Content containers: `max-width` with `margin-inline: auto` for centering
+- Never use `position: fixed` for content that obscures focused elements (2.4.12)
+
+---
+
+## Component States
+
+### Focus State (2.4.13)
+
+All interactive elements must have a highly visible focus state. The default in `tokens.css` is a 3px solid outline with a 2px offset.
+
+```css
+:focus-visible {
+  outline: 3px solid var(--color-focus);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+```
+
+### Disabled State
+
+Avoid disabling buttons and inputs where possible. It is often more accessible to leave them enabled and show an error on interaction. If you must disable an element, use `aria-disabled="true"` instead of the `disabled` attribute for elements that are not focusable by default. This keeps them in the tab order so screen reader users are aware of them.
+
+```css
+[aria-disabled="true"] {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+```
+
+---
+
+## Component Patterns
+
+### Buttons
+
+```css
+.btn {
+  min-height: var(--target-size-min);
+  min-width: var(--target-size-min);
+  padding: var(--space-2) var(--space-5);
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  line-height: var(--leading-heading);
+  border: 2px solid transparent;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out;
+}
+
+.btn:focus-visible {
+  outline: 3px solid var(--color-focus);
+  outline-offset: 2px;
+}
+```
+
+### Form Controls
+
+```css
+.form-control {
+  min-height: var(--target-size-min);
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-base);
+  line-height: var(--leading-heading);
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  width: 100%;
+}
+
+.form-control:focus-visible {
+  outline: 3px solid var(--color-focus);
+  outline-offset: 2px;
+  border-color: var(--color-focus);
+}
+
+.form-label {
+  display: block;
+  font-weight: var(--font-semibold);
+  margin-block-end: var(--space-2);
+  color: var(--color-text);
+}
+
+.form-error {
+  color: var(--color-error);
+  font-size: var(--text-sm);
+  margin-block-start: var(--space-1);
+}
+```
+
+### Links
+
+```css
+a {
+  color: var(--color-primary);
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
+a:hover {
+  color: var(--color-primary-dark);
+}
+
+a:focus-visible {
+  outline: 3px solid var(--color-focus);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+```
+
+Always use underlines on links. Never rely on color alone to distinguish links from surrounding text (1.4.1).
+
+---
+
+## Internationalization & Layout
+
+### CSS Logical Properties
+
+Use logical properties (`margin-inline-start`, `padding-inline-end`, `border-block-start`) instead of directional properties (`margin-left`, `padding-right`, `border-top`) to support right-to-left (RTL) and vertical writing modes automatically.
+
+| Directional | Logical (LTR) | Logical (RTL) |
+|-------------|-----------------|---------------|
+| `margin-left` | `margin-inline-start` | `margin-right` |
+| `padding-right` | `padding-inline-end` | `padding-left` |
+| `border-top` | `border-block-start` | `border-top` |
+
+### Fluid Typography
+
+Use `clamp()` for font sizes to create fluid typography that scales smoothly with the viewport, improving readability on all screen sizes.
+
+```css
+/* Example for H1 */
+h1 {
+  font-size: clamp(1.8rem, 1.5rem + 2vw, 2.25rem);
+}
+```
+
+---
+
+## Tone and Language
+
+### Corporate/Formal Writing Rules
+
+- No emoji in any user-facing text
+- Use complete sentences with proper punctuation
+- Use formal vocabulary; avoid slang, colloquialisms, and contractions
+- Use title case for headings and navigation labels
+- Use sentence case for body text and descriptions
+- Provide definitions for technical terms and abbreviations (3.1.3, 3.1.4)
+- Write at a clear, professional reading level; provide summaries for complex content (3.1.5)
+- Use structured layouts: headings, tables, and ordered lists to organize information
+- Every page section must have a descriptive heading (2.4.10)
+
+---
+
+## Visual Hierarchy & Information Density
+
+In corporate design, the goal is a clear, scannable path through dense information. This is achieved by minimizing unnecessary variation and using space deliberately.
+
+### Visual Hierarchy Rules
+
+- **Limit Type Sizes**: Use no more than 4 distinct sizes for headings and body text to create a clear hierarchy without clutter.
+- **Limit Colors**: Adhere to a strict color palette (e.g., 2 primary, 2 secondary colors) to maintain a formal tone.
+- **Limit Contrast Levels**: Use no more than 3 levels of text contrast (e.g., primary, secondary, disabled) to guide the user's attention.
+
+### Information Density
+
+Enterprise users often need to see a lot of data at once. The design must support this without becoming overwhelming. Provide controls to adjust density where appropriate (e.g., in data tables).
+
+| Density | Use Case |
+|---|---|
+| **Compact** | For power users and data-heavy screens where maximizing visible data is critical. Uses smaller spacing and tighter layouts. |
+| **Comfortable** | The default for most applications. A balance between information density and readability. |
+| **Spacious** | For applications that are less data-intensive or will be used on touch devices. Uses generous spacing. |

--- a/skills/accessibility/references/corporate-ux-patterns.md
+++ b/skills/accessibility/references/corporate-ux-patterns.md
@@ -1,0 +1,73 @@
+# Corporate Web Application UX Patterns
+
+## Table of Contents
+
+1. [Core Principles of Enterprise UX](#core-principles-of-enterprise-ux)
+2. [Key Pattern Categories](#key-pattern-categories)
+3. [Visual Hierarchy & Information Density](#visual-hierarchy--information-density)
+
+---
+
+This document provides best practices and patterns for designing formal, corporate, and enterprise web applications. These guidelines supplement the core WCAG AAA requirements with a focus on usability, efficiency, and scalability for complex, data-intensive systems.
+
+## Core Principles of Enterprise UX
+
+Corporate web applications prioritize efficiency, clarity, and role-based functionality over aesthetic trends. The design must reduce cognitive load for users who may spend hours in the application daily.
+
+| Principle | Description | Key Implementation |
+|---|---|---|
+| **Efficiency Over Delight** | The primary goal is to help users complete complex tasks quickly and accurately. | Streamlined workflows, keyboard shortcuts, and predictable interfaces. |
+| **Role-Based Design** | The application must serve multiple user roles, from beginners to power users, each with different needs. | Customizable dashboards, role-specific navigation, and feature sets. |
+| **High Information Density** | Enterprise users often need to see large amounts of data at once to make informed decisions. The design must balance density with clarity. | Compact data tables, effective use of whitespace, and clear visual hierarchy. |
+| **Progressive Disclosure** | To avoid overwhelming users, advanced options and secondary information should be hidden by default and revealed only when needed. | Use of disclosures, modals, and side panels to show contextual information. |
+| **Scalable Design Systems** | The UI must be consistent across a large, evolving application. | Strict adherence to a design system with reusable components and patterns. |
+
+---
+
+## Key Pattern Categories
+
+This skill provides detailed guidance on the following critical pattern categories for corporate web applications. Consult these documents for implementation details.
+
+### 1. Application States
+
+Properly communicating application states is crucial for preventing user confusion and building trust. An application is not always full of data; it can be loading, empty, or in an error state.
+
+**[➡️ See full guidance: `application-states.md`](./application-states.md)**
+
+- **Loading States**: Use skeleton screens to provide a low-fidelity preview of the UI, which reduces perceived wait time compared to a generic spinner.
+- **Empty States**: Design for first-use, "no results," and success scenarios. Guide the user on what to do next.
+- **Error States**: Provide clear, actionable error messages. Distinguish between system errors and user input validation errors.
+
+### 2. Data Presentation
+
+Presenting complex data is a core function of most corporate applications. The goal is to make data scannable, comparable, and actionable.
+
+**[➡️ See full guidance: `data-presentation.md`](./data-presentation.md)**
+
+- **Data Tables**: The workhorse of enterprise UX. Must support sorting, filtering, and customization. Follow strict alignment and typography rules.
+- **Dashboards**: Provide a high-level overview of key metrics and system status. Should be role-based and customizable.
+
+### 3. Navigation Patterns
+
+Navigation in complex applications must be predictable and efficient, providing clear pathways through a deep information architecture.
+
+**[➡️ See full guidance: `navigation-patterns.md`](./navigation-patterns.md)**
+
+- **Sidebar Navigation**: Ideal for applications with a deep, hierarchical structure. Allows for persistent global navigation.
+- **Tabbed Navigation**: Useful for switching between different views or datasets within the same context.
+- **Breadcrumbs**: Essential for showing the user's location within a deep hierarchy and providing a quick way to navigate up the tree.
+
+---
+
+## Visual Hierarchy & Information Density
+
+In corporate design, visual hierarchy is not about flashy graphics but about creating a clear, scannable path through dense information.
+
+- **Limit Variation**: A formal aesthetic is achieved by minimizing variation. Adhere to these rules:
+    - **Type Sizes**: Use no more than 3-4 distinct sizes for headings and body text.
+    - **Colors**: Use a limited palette (e.g., 2 primary, 2 secondary colors) and ensure all have AAA contrast.
+    - **Contrast Levels**: Use no more than 3 levels of text contrast (e.g., primary text, secondary text, disabled text).
+
+- **Embrace Whitespace**: While information density is high, whitespace (or negative space) is the most powerful tool for creating groups and directing attention. Use it deliberately to separate sections and reduce cognitive load.
+
+- **The Squint Test**: When you squint at the interface, the most important elements should still stand out. The overall structure and hierarchy should be apparent even when the details are blurred.

--- a/skills/accessibility/references/data-presentation.md
+++ b/skills/accessibility/references/data-presentation.md
@@ -1,0 +1,56 @@
+# Data Presentation Patterns
+
+## Table of Contents
+
+1. [Data Tables](#1-data-tables)
+2. [Dashboards](#2-dashboards)
+
+---
+
+This document provides patterns for presenting complex data in corporate web applications, focusing on data tables and dashboards.
+
+## 1. Data Tables
+
+Data tables are the most common and effective way to display large, structured datasets in enterprise applications. A well-designed table allows users to scan, compare, and act on data efficiently.
+
+### Key Principles
+
+- **Readability is Paramount**: The design must optimize for quick scanning and comparison.
+- **Give Users Control**: Allow users to customize the view to fit their specific needs.
+- **Actions in Context**: Provide actions where the user needs them, without cluttering the interface.
+
+### Anatomy & Best Practices
+
+| Element | Best Practice |
+|---|---|
+| **Alignment** | - **Text**: Left-align. <br> - **Numbers**: Right-align. <br> - **Headers**: Align with their column content. <br> - **NEVER** use center alignment. |
+| **Typography** | Use a **monospace/tabular font** for all numeric columns to ensure numbers align correctly for easy comparison. |
+| **Row Style** | Use simple **line divisions** between rows. Avoid zebra stripes, as they create visual noise and complicate hover/selected states. |
+| **Column Management** | - **Sticky Header**: The table header must remain visible on vertical scroll. <br> - **Freeze Columns**: The first column (and action columns) should be frozen on horizontal scroll. <br> - **Customization**: Allow users to **reorder, hide, and resize** columns. Always provide a "Reset to Default" option. |
+| **Display Density** | Provide options for users to switch between display densities: <br> - **Compact**: For power users who need to see maximum data. <br> - **Comfortable**: A balanced default. <br> - **Spacious**: For readability and touch-friendliness. |
+| **Actions** | - **Bulk Actions**: Display a toolbar above the table *only after* the user selects one or more rows. <br> - **Row-Level Actions**: Reveal actions (e.g., Edit, Delete) on hover to reduce visual clutter. |
+| **Pagination** | Use clear pagination controls at the bottom of the table. Include a "rows per page" selector. |
+
+### Example: Accessible Data Table Template
+
+An HTML template for an accessible data table is provided in `templates/data-table.html`.
+
+---
+
+## 2. Dashboards
+
+Dashboards provide a high-level, at-a-glance view of key performance indicators (KPIs), metrics, and system status. They are a central component of many corporate applications.
+
+### Key Principles
+
+- **Role-Based**: The information displayed should be tailored to the user's role and objectives.
+- **Scannable**: The most important information should be immediately obvious. Use visual hierarchy to guide the user's eye.
+- **Actionable**: Dashboards should not just display data; they should provide pathways to investigate and act on that data.
+
+### Layout & Content
+
+- **Inverted Pyramid**: Place the most critical, summary-level information at the top-left. As the user moves down and to the right, provide more detailed information.
+- **Use a Grid**: A consistent grid system (like the one in `responsive.css`) is essential for a clean, organized layout.
+- **Group Related Information**: Use cards or tiles to group related metrics. Use whitespace to create clear separation between groups.
+- **Prioritize Data, Not Decoration**: Avoid superfluous icons or illustrations that can distract from the data itself. The data is the interface.
+- **Provide Drill-Downs**: Each dashboard component should be a gateway to more detailed information. Clicking on a chart or KPI should navigate the user to a more detailed report or data table.

--- a/skills/accessibility/references/form-patterns.md
+++ b/skills/accessibility/references/form-patterns.md
@@ -1,0 +1,163 @@
+# Accessible Form Patterns
+
+This guide provides industrial best practices for creating fully accessible forms that meet WCAG 2.2 AAA requirements. It covers labeling, grouping, validation, and error handling.
+
+## Table of Contents
+
+1.  [Labeling and Instructions](#labeling-and-instructions)
+2.  [Grouping Related Controls](#grouping-related-controls)
+3.  [Error Identification & Validation](#error-identification--validation)
+4.  [Providing Help and Suggestions](#providing-help-and-suggestions)
+
+---
+
+## Labeling and Instructions (3.3.2)
+
+Every form control must have a programmatically associated label.
+
+### Best Practice: Explicit `<label>`
+
+Always use an explicit `<label>` with a `for` attribute that matches the `id` of the form control. This is the most robust method.
+
+```html
+<label for="first-name">First Name</label>
+<input type="text" id="first-name" name="first-name" autocomplete="given-name">
+```
+
+### Instructions and Formatting Requirements
+
+For complex inputs, provide instructions. Use `aria-describedby` to link instructions to the input so screen readers announce them.
+
+```html
+<label for="password">Password</label>
+<input type="password" id="password" name="password" aria-describedby="password-hint">
+<p id="password-hint">Must be at least 12 characters long and include a number.</p>
+```
+
+---
+
+## Grouping Related Controls (1.3.1, 3.3.2)
+
+Use `<fieldset>` and `<legend>` to group related sets of controls, such as radio buttons or checkboxes.
+
+-   The `<fieldset>` groups the controls.
+-   The `<legend>` provides a visible label for the entire group.
+
+This is essential for screen reader users to understand the context of questions with multiple choices.
+
+### Example: Radio Button Group
+
+```html
+<fieldset>
+  <legend>Choose your delivery option</legend>
+
+  <input type="radio" id="standard" name="delivery" value="std">
+  <label for="standard">Standard Delivery</label>
+
+  <input type="radio" id="express" name="delivery" value="exp">
+  <label for="express">Express Delivery</label>
+</fieldset>
+```
+
+---
+
+## Security: CSRF and XSS Prevention
+
+All forms that perform state-changing actions (e.g., POST, PUT, DELETE) MUST be protected against Cross-Site Request Forgery (CSRF). All user input rendered back to the page MUST be encoded to prevent Cross-Site Scripting (XSS).
+
+### CSRF: Synchronizer Token Pattern
+
+1.  **Generate Token**: On the server, generate a unique, random token for the user session.
+2.  **Embed Token**: Include the token in a hidden `<input>` field in every state-changing form.
+3.  **Verify Token**: On submission, the server MUST verify that the token from the form matches the one stored in the session.
+
+```html
+<form action="/update-profile" method="post">
+  <input type="hidden" name="_csrf" value="{{CSRF_TOKEN}}">
+  <!-- other form fields -->
+</form>
+```
+
+### XSS: Output Encoding
+
+When re-displaying user input (e.g., after a validation error), always use `textContent` to prevent the browser from interpreting it as HTML.
+
+```javascript
+// When re-populating a form field after a server-side error:
+document.getElementById("email").value = submittedEmail; // SAFE
+
+// When displaying submitted content:
+document.getElementById("comment-display").textContent = submittedComment; // SAFE
+```
+
+---
+
+## Error Identification & Validation (3.3.1, 3.3.3)
+
+When a form submission fails, errors must be identified clearly and programmatically.
+
+### Best Practice: Inline Errors + Error Summary
+
+1.  **Error Summary**: At the top of the form, display a summary of all errors. This should be contained in an element with `role="alert"` to ensure it is announced immediately. Each error in the summary should be a link that jumps the user to the corresponding invalid field.
+
+2.  **Inline Errors**: Display a specific error message directly next to the invalid field.
+
+3.  **Programmatic Association**: Link the error message to the input using `aria-describedby`. Also, set `aria-invalid="true"` on the input.
+
+### Example: Invalid Email Field
+
+```html
+<!-- Error Summary at top of form -->
+<div role="alert">
+  <h2>Please correct the following errors:</h2>
+  <ul>
+    <li><a href="#email">Email address is not valid.</a></li>
+  </ul>
+</div>
+
+<!-- Form Field -->
+<label for="email">Email Address</label>
+<input type="email" id="email" name="email" aria-invalid="true" aria-describedby="email-error">
+<p id="email-error" class="form-error">Please enter a valid email address.</p>
+```
+
+### Confirmation for Destructive Actions (3.3.4)
+
+For any form submission that is destructive or irreversible (e.g., deleting data, making a payment), you MUST provide a confirmation step.
+
+-   **Pattern**: Use a JavaScript `confirm()` dialog for simplicity, or a full confirmation modal for more complex scenarios.
+-   **Implementation**: Add a `data-confirm="Are you sure?"` attribute to the submit button and use the provided `initConfirmActions()` function in `templates/main.js`.
+
+```html
+<button type="submit" data-confirm="Are you sure you want to delete this item?">Delete</button>
+```
+
+### Validation Strategy
+
+-   **Client-Side**: Provide real-time feedback where possible, but do not be overly aggressive. Validate on blur or on submit.
+-   **Server-Side**: Always re-validate on the server. Never trust client-side validation alone.
+-   **Error Prevention (3.3.4, 3.3.6)**: For legal, financial, or data-modifying forms, all submissions MUST be reversible, checked, or confirmed. Provide a confirmation page before final submission.
+
+---
+
+## Providing Help and Suggestions (3.3.5)
+
+For complex forms, provide context-sensitive help.
+
+### Help Text
+
+Use `aria-describedby` to associate persistent help text with a field, as shown in the password example above.
+
+### Tooltips
+
+If using a help icon with a tooltip, ensure the tooltip is accessible. Follow the Tooltip pattern in `references/aria-patterns.md`. The help icon button should have an `aria-label` like "Help for Password field".
+
+### Error Suggestions (3.3.3)
+
+When an error is correctable, provide a suggestion. For example, if a username is taken, suggest alternatives.
+
+```html
+<p id="username-error" class="form-error">
+  Username "simon" is already taken. Did you mean "simon123"?
+</p>
+```

--- a/skills/accessibility/references/navigation-patterns.md
+++ b/skills/accessibility/references/navigation-patterns.md
@@ -1,0 +1,73 @@
+# Corporate Navigation Patterns
+
+## Table of Contents
+
+1. [Primary Navigation Patterns](#1-primary-navigation-patterns)
+2. [Secondary Navigation Patterns](#2-secondary-navigation-patterns)
+
+---
+
+Navigation in complex corporate and enterprise web applications must be predictable, efficient, and scalable. It provides the information architecture for the entire system.
+
+## 1. Primary Navigation Patterns
+
+Choose a primary navigation pattern based on the application's complexity and structure.
+
+### Pattern: Collapsible Sidebar Navigation
+
+This is the **recommended default** for most corporate web applications.
+
+![Sidebar Navigation Example](https://carbondesignsystem.com/static/4a2f5d13f5919e0a04098999334583a3/2923f/Global-header-w-side-nav.png)
+*(Source: IBM Carbon Design System)*
+
+**When to Use:**
+- The application has a deep, hierarchical information architecture (e.g., more than 5-7 top-level items).
+- Users need to frequently switch between different sections or modules.
+
+**Best Practices:**
+- **Collapsible**: The sidebar should be collapsible to maximize content space when needed.
+- **Icons and Text**: Use both icons and clear text labels for top-level items. On collapse, show icons with tooltips.
+- **Hierarchy**: Use accordions or fly-out menus to reveal nested sub-navigation items.
+- **Stateful**: The navigation should clearly indicate the user's current location (`aria-current="page"`).
+
+### Pattern: Top Navigation (Header)
+
+**When to Use:**
+- The application has a relatively flat structure with a limited number of primary sections (typically 5-7 items).
+- The primary focus is on the content, and vertical space is not a major concern.
+
+**Best Practices:**
+- **Limited Items**: Do not overcrowd the top navigation. If you have more than 7 items, consider a sidebar.
+- **Descriptive Labels**: Use short, clear labels (1-2 words).
+- **Dropdowns for Sub-items**: Use dropdown menus (`<button>` with `aria-haspopup="true"`) for sub-navigation, but avoid more than one level of nesting.
+
+---
+
+## 2. Secondary Navigation Patterns
+
+These patterns help users navigate within a specific section of the application.
+
+### Pattern: Tabbed Navigation
+
+Tabs are excellent for switching between different views or datasets within the same context.
+
+**When to Use:**
+- To alternate between different representations of the same data (e.g., "Table View" vs. "Chart View").
+- To break down a complex page into logical sections (e.g., "Settings > Profile", "Settings > Notifications").
+
+**Best Practices:**
+- **Use ARIA Tabs Pattern**: Follow the WAI-ARIA pattern for tabs, which uses `role="tablist"`, `role="tab"`, and `role="tabpanel"`. An implementation is in `/references/aria-patterns.md`.
+- **Don't Use for Sequential Steps**: Tabs are for alternating views, not for a multi-step process. Use a stepper or wizard for that.
+
+### Pattern: Breadcrumbs
+
+Breadcrumbs are a critical secondary navigation aid that shows the user's location in the site hierarchy.
+
+**When to Use:**
+- In any application with more than two levels of depth.
+
+**Best Practices:**
+- **Show the Path**: Display the full path from the homepage to the current page.
+- **Last Item is Current Page**: The last item in the breadcrumb trail should be the current page and should not be a link.
+- **Use `aria-label`**: The `<nav>` element containing the breadcrumbs should have an `aria-label="breadcrumb"`.
+- **Separator**: Use a simple separator (e.g., `/` or `>`) between links. This should be done with CSS `::before` content for accessibility.

--- a/skills/accessibility/references/responsive-breakpoints.md
+++ b/skills/accessibility/references/responsive-breakpoints.md
@@ -1,0 +1,182 @@
+# Responsive Design Patterns
+
+Device-sensitive design patterns for WCAG AAA compliant web applications. All breakpoints use mobile-first methodology with `min-width` media queries.
+
+## Table of Contents
+
+1. [Breakpoint System](#breakpoint-system)
+2. [Layout Patterns by Breakpoint](#layout-patterns-by-breakpoint)
+3. [AAA-Specific Responsive Considerations](#aaa-specific-responsive-considerations)
+4. [Touch Target Sizing](#touch-target-sizing)
+
+---
+
+## Breakpoint System
+
+Three required breakpoints (minimum), with two optional enhancements:
+
+| Token | Range | Target Devices | CSS Variable |
+|-------|-------|----------------|--------------|
+| `sm` | 0 -- 767px | Phones (portrait/landscape) | `--bp-sm: 0px` |
+| `md` | 768px -- 1023px | Tablets, small laptops | `--bp-md: 768px` |
+| `lg` | 1024px+ | Desktops, large screens | `--bp-lg: 1024px` |
+| `xl` (optional) | 1280px+ | Wide desktops | `--bp-xl: 1280px` |
+| `xxl` (optional) | 1536px+ | Ultra-wide displays | `--bp-xxl: 1536px` |
+
+### CSS Custom Properties (Framework-Agnostic)
+
+```css
+:root {
+  --bp-sm: 0px;
+  --bp-md: 768px;
+  --bp-lg: 1024px;
+  --bp-xl: 1280px;
+  --bp-xxl: 1536px;
+}
+
+/* Mobile-first: base styles apply to sm */
+/* md and up */
+@media (min-width: 768px) { }
+/* lg and up */
+@media (min-width: 1024px) { }
+/* xl and up (optional) */
+@media (min-width: 1280px) { }
+```
+
+### Container Width Strategy
+
+| Breakpoint | Container Max-Width | Side Padding |
+|------------|-------------------|--------------|
+| sm | 100% | 16px (1rem) |
+| md | 720px | 24px (1.5rem) |
+| lg | 960px | 32px (2rem) |
+| xl | 1140px | 32px (2rem) |
+| xxl | 1320px | 32px (2rem) |
+
+Enforce `max-width: 80ch` on text blocks to satisfy WCAG 1.4.8 (max 80 characters per line).
+
+---
+
+## Layout Patterns by Breakpoint
+
+### Header/Navigation
+
+| Breakpoint | Pattern |
+|------------|---------|
+| sm | Hamburger menu with off-canvas panel; logo left-aligned; essential actions visible |
+| md | Condensed horizontal nav or priority+ pattern; logo + primary links visible |
+| lg+ | Full horizontal navigation; logo + all nav items + utility links |
+
+Navigation must be keyboard-operable at all breakpoints. Hamburger toggle must have `aria-expanded`, `aria-controls`, and `aria-label`.
+
+### Content Grid
+
+| Breakpoint | Columns | Gutter |
+|------------|---------|--------|
+| sm | 1 column (stacked) | 16px |
+| md | 2 columns | 24px |
+| lg | 3--4 columns | 32px |
+
+Use CSS Grid or Flexbox. Never use `float`-based layouts. Grid areas must maintain logical reading order in DOM regardless of visual placement.
+
+### Footer
+
+| Breakpoint | Pattern |
+|------------|---------|
+| sm | Single column, stacked sections, full-width links (44px min-height) |
+| md | 2-column grid for link groups |
+| lg+ | Multi-column layout with all sections visible |
+
+---
+
+## AAA-Specific Responsive Considerations
+
+### Reflow (1.4.10)
+Content must reflow without horizontal scrolling at 320px CSS width (equivalent to 400% zoom on a 1280px viewport). Test by setting browser width to 320px.
+
+### Text Resize (1.4.4)
+All text must remain readable and functional at 200% browser zoom. Use `rem` or `em` units for font sizes, never `px` for body text.
+
+### Orientation (1.3.4)
+Never lock orientation. Content must function in both portrait and landscape. Test both orientations at every breakpoint.
+
+### Touch Targets (2.5.5 AAA)
+All interactive elements must be at least 44x44 CSS pixels at every breakpoint. This is especially critical on sm/md breakpoints where touch is primary input.
+
+### Spacing for Touch (AAA)
+Minimum 8px gap between adjacent interactive elements to prevent accidental activation.
+
+---
+
+## Modern CSS Layout
+
+### Container Queries
+
+Use container queries to create components that respond to the width of their container, not just the viewport. This makes components more modular and reusable.
+
+```css
+.card-container {
+  container-type: inline-size;
+}
+
+/* Styles apply when the container is > 400px wide */
+@container (min-width: 400px) {
+  .card {
+    flex-direction: row;
+  }
+}
+```
+
+### Fluid Spacing
+
+Use `clamp()` for padding and margins to create fluid spacing that adapts to the viewport, preventing overly large or small gaps.
+
+```css
+.section {
+  padding-block: clamp(2rem, 1rem + 5vw, 6rem);
+}
+```
+
+---
+
+## Touch Target Sizing
+
+### Minimum Dimensions by Element Type
+
+| Element | Min Width | Min Height | Notes |
+|---------|-----------|------------|-------|
+| Buttons | 44px | 44px | Includes padding |
+| Links (inline) | N/A | 44px line-height | Ensure sufficient vertical space |
+| Links (nav/list) | 44px | 44px | Full clickable area |
+| Form inputs | 100% (sm) | 44px | Full-width on mobile |
+| Checkboxes/radios | 44px | 44px | Use padding or label click area |
+| Icon buttons | 44px | 44px | Touch area may exceed visual icon |
+
+### Implementation Pattern
+
+```css
+/* Ensure all interactive elements meet AAA target size */
+button,
+[role="button"],
+input[type="submit"],
+input[type="reset"],
+input[type="button"],
+select,
+a:not([class*="inline"]) {
+  min-height: 44px;
+  min-width: 44px;
+}
+
+input[type="text"],
+input[type="email"],
+input[type="password"],
+input[type="search"],
+input[type="tel"],
+input[type="url"],
+input[type="number"],
+textarea,
+select {
+  min-height: 44px;
+  padding: 0.5rem 0.75rem;
+}
+```

--- a/skills/accessibility/references/security-error-handling.md
+++ b/skills/accessibility/references/security-error-handling.md
@@ -1,0 +1,159 @@
+# Web App Security & Error Handling Patterns
+
+This document provides essential security and error handling patterns for building production-grade, full-stack web applications. It covers defensive coding, secure configuration, and robust error management to protect against common vulnerabilities and ensure a reliable user experience.
+
+## Table of Contents
+
+1.  [Web Application Security](#web-application-security)
+    *   [HTTP Security Headers](#http-security-headers)
+    *   [Content Security Policy (CSP)](#content-security-policy-csp)
+    *   [Cross-Site Scripting (XSS) Prevention](#cross-site-scripting-xss-prevention)
+    *   [Cross-Site Request Forgery (CSRF) Prevention](#cross-site-request-forgery-csrf-prevention)
+    *   [Secrets Management](#secrets-management)
+2.  [Robust Error Handling](#robust-error-handling)
+    *   [Client-Side API Error Handling](#client-side-api-error-handling)
+    *   [Global JavaScript Error Handling](#global-javascript-error-handling)
+
+---
+
+## Web Application Security
+
+Security is not a feature but a foundational requirement. The following patterns provide defense-in-depth against the most common web vulnerabilities.
+
+### HTTP Security Headers
+
+HTTP security headers are a critical, server-side defense mechanism that instructs the browser on how to behave when handling your site’s content. They should be configured on your web server or reverse proxy.
+
+| Header | Purpose & Recommended Value |
+| --- | --- |
+| `Content-Security-Policy` | Prevents XSS, clickjacking, and other injection attacks. See the [CSP section](#content-security-policy-csp) for a strict policy. |
+| `Strict-Transport-Security` | Enforces secure (HTTPS) connections. `max-age=63072000; includeSubDomains; preload` |
+| `X-Content-Type-Options` | Prevents MIME-sniffing attacks. `nosniff` |
+| `Referrer-Policy` | Controls how much referrer information is sent. `strict-origin-when-cross-origin` |
+| `Permissions-Policy` | Disables browser features that are not needed. `camera=(), microphone=(), geolocation=()` |
+| `Cross-Origin-Opener-Policy` | Protects against cross-origin attacks. `same-origin` |
+
+### Content Security Policy (CSP)
+
+A strict CSP is the most effective way to mitigate injection vulnerabilities. It drastically reduces the attack surface by telling the browser which dynamic resources are allowed to load.
+
+**Best Practice: Nonce-Based Strict CSP**
+
+This approach is highly secure and easier to maintain than allowlist-based policies.
+
+1.  **Generate a Nonce**: For every server-rendered page request, generate a unique, random, base64-encoded string (the "nonce").
+2.  **Set the Header**: Include the nonce in the `Content-Security-Policy` header.
+3.  **Apply to Scripts**: Add a `nonce="{{YOUR_NONCE}}"` attribute to every legitimate `<script>` tag on the page.
+
+**Recommended Strict Policy Template:**
+
+```http
+Content-Security-Policy:
+  script-src 'nonce-{{YOUR_NONCE}}' 'strict-dynamic';
+  object-src 'none';
+  base-uri 'none';
+  require-trusted-types-for 'script';
+```
+
+-   `script-src 'nonce-...' 'strict-dynamic'`: Allows scripts with the correct nonce to execute, and allows those scripts to load other scripts.
+-   `object-src 'none'`: Disables legacy plugins like Flash.
+-   `base-uri 'none'`: Prevents attackers from changing the base URL of the page.
+-   `require-trusted-types-for 'script'`: Enforces DOM XSS protection.
+
+### Cross-Site Scripting (XSS) Prevention
+
+XSS occurs when an attacker injects malicious scripts into a trusted website. The primary defense is to **never trust user input** and to properly encode all output.
+
+**Rule 1: Use `textContent` over `innerHTML`**
+
+To prevent DOM-based XSS, always use `element.textContent` to insert data into the page. Never use `innerHTML` with user-provided content.
+
+```javascript
+// SAFE: Automatically encodes HTML
+document.getElementById('user-comment').textContent = untrustedUserData;
+
+// UNSAFE: Renders HTML, allowing script execution
+document.getElementById('user-comment').innerHTML = untrustedUserData;
+```
+
+**Rule 2: Sanitize HTML with DOMPurify**
+
+If you absolutely must render user-provided HTML, sanitize it first with a library like [DOMPurify](https://github.com/cure53/DOMPurify).
+
+```javascript
+import DOMPurify from 'dompurify';
+const cleanHTML = DOMPurify.sanitize(untrustedHTML);
+document.getElementById('content').innerHTML = cleanHTML;
+```
+
+### Cross-Site Request Forgery (CSRF) Prevention
+
+CSRF tricks a user's browser into making an unwanted request to your application on their behalf. The standard defense is the **Synchronizer Token Pattern**.
+
+1.  **Generate Token**: When rendering a form, the server generates a unique, random token (CSRF token).
+2.  **Embed Token**: The token is embedded in a hidden `<input>` field within the form.
+3.  **Verify Token**: When the form is submitted, the server checks that the token from the form body matches the token it expects for that user's session. If they don't match, the request is rejected.
+
+**Example Form with CSRF Token:**
+
+```html
+<form action="/update-profile" method="post">
+  <input type="hidden" name="_csrf" value="{{CSRF_TOKEN}}">
+  <!-- other form fields -->
+  <button type="submit">Update</button>
+</form>
+```
+
+### Secrets Management
+
+Never hardcode API keys, database credentials, or other secrets directly in your front-end or back-end code. Use environment variables to store secrets and load them at runtime.
+
+-   **Front-End**: Use build tool features (e.g., Vite's `import.meta.env.VITE_API_KEY`) to expose non-critical keys. **Never** expose server-side or high-privilege keys to the client.
+-   **Back-End**: Use a `.env` file locally and your hosting provider's secret management system in production.
+
+---
+
+## Robust Error Handling
+
+### Client-Side API Error Handling
+
+Web applications must gracefully handle API failures. A robust pattern involves a centralized API client that handles common error scenarios.
+
+**API Client Logic:**
+
+1.  **Check Network Errors**: Wrap `fetch` calls in a `try...catch` block to handle network failures or DNS issues.
+2.  **Check HTTP Status**: If a response is received, check `response.ok`. If it's `false` (e.g., status 404, 500), parse the error body and throw a structured error.
+3.  **Handle Timeouts**: Use an `AbortController` to implement request timeouts.
+4.  **Implement Retry Logic**: For transient errors (e.g., 503 Service Unavailable), implement an exponential backoff retry mechanism.
+
+**Example API Error Structure:**
+
+```json
+{
+  "error": {
+    "status": 401,
+    "code": "UNAUTHORIZED",
+    "message": "Authentication token is missing or invalid."
+  }
+}
+```
+
+### Global JavaScript Error Handling
+
+To catch unexpected errors and prevent the application from crashing, implement global error handlers.
+
+**Pattern: Error Boundaries & Global Handlers**
+
+-   **Error Boundaries (React)**: In React, wrap sections of your UI in an Error Boundary component. It will catch rendering errors in its children, log them, and display a fallback UI.
+-   **Global Handlers (Vanilla JS)**: Use `window.onerror` and `window.onunhandledrejection` to catch uncaught synchronous errors and unhandled promise rejections. These handlers are the last line of defense and should be used to log the error to a monitoring service and inform the user that something went wrong.
+
+**Example: Global Error Handler**
+
+```javascript
+window.onerror = function(message, source, lineno, colno, error) {
+  console.error('Caught unhandled error:', { message, source, lineno, error });
+  // Log to a remote service
+  // Show a generic error message to the user
+  return true; // Prevents the default browser error handling
+};
+```

--- a/skills/accessibility/references/wcag-aaa-checklist.md
+++ b/skills/accessibility/references/wcag-aaa-checklist.md
@@ -1,0 +1,200 @@
+# WCAG 2.2 AAA Success Criteria Checklist
+
+This reference covers all 87 WCAG 2.2 success criteria (A + AA + AAA cumulative) organized by the four POUR principles. Use this as a design-time and review-time checklist.
+
+## Table of Contents
+
+1. [Perceivable (28 Criteria)](#perceivable)
+2. [Operable (29 Criteria)](#operable)
+3. [Understandable (17 Criteria)](#understandable)
+4. [Robust (2 Criteria)](#robust)
+5. [AAA-Specific Design Implications](#aaa-specific-design-implications)
+
+---
+
+## Perceivable
+
+### 1.1 Text Alternatives
+
+| SC | Level | Requirement | Implementation |
+|----|-------|-------------|----------------|
+| 1.1.1 | A | Text alternatives for non-text content | Every `<img>` has descriptive `alt`; decorative images use `alt=""`; complex images have long descriptions |
+
+### 1.2 Time-Based Media
+
+| SC | Level | Requirement | Implementation |
+|----|-------|-------------|----------------|
+| 1.2.1 | A | Alternatives for prerecorded audio/video | Provide transcript or text alternative |
+| 1.2.2 | A | Captions for prerecorded audio in video | Synchronized captions for all video |
+| 1.2.3 | A | Audio description or media alternative | Audio description track or full text alternative |
+| 1.2.4 | AA | Captions for live audio | Real-time captions for live streams |
+| 1.2.5 | AA | Audio description for prerecorded video | Narrated description of visual content |
+| 1.2.6 | AAA | Sign language for prerecorded content | Embedded sign language interpretation |
+| 1.2.7 | AAA | Extended audio description | Pause video to insert descriptions when gaps are insufficient |
+| 1.2.8 | AAA | Full text alternative for prerecorded media | Complete text transcript of all audio and visual information |
+| 1.2.9 | AAA | Alternative for live audio-only | Real-time text alternative for live audio |
+
+### 1.3 Adaptable
+
+| SC | Level | Requirement | Implementation |
+|----|-------|-------------|----------------|
+| 1.3.1 | A | Info and relationships in code | Use semantic HTML (`<nav>`, `<main>`, `<article>`, `<aside>`, `<header>`, `<footer>`, `<section>`); proper heading hierarchy; `<table>` with `<th>` and `scope` |
+| 1.3.2 | A | Meaningful sequence | DOM order matches visual order; CSS does not reorder content in ways that break reading sequence |
+| 1.3.3 | A | Sensory characteristics | Never rely solely on shape, color, size, position, or sound to convey information |
+| 1.3.4 | AA | Orientation | Content not restricted to portrait or landscape; use flexible layouts |
+| 1.3.5 | AA | Identify input purpose | Use `autocomplete` attributes on form fields for personal data |
+| 1.3.6 | AAA | Identify purpose | Use ARIA landmarks, `role` attributes, and microdata to identify UI component purpose |
+
+### 1.4 Distinguishable
+
+| SC | Level | Requirement | Implementation |
+|----|-------|-------------|----------------|
+| 1.4.1 | A | Use of color | Never use color as the sole indicator; pair with text, icons, or patterns |
+| 1.4.2 | A | Audio control | Auto-playing audio has pause/stop/mute within first 3 seconds |
+| 1.4.3 | AA | Contrast minimum | 4.5:1 for normal text, 3:1 for large text (>=18pt or >=14pt bold) |
+| 1.4.4 | AA | Resize text | Text resizable to 200% without loss of content or function |
+| 1.4.5 | AA | Images of text | Use real text, not images of text (except logos) |
+| 1.4.6 | **AAA** | **Contrast enhanced** | **7:1 for normal text, 4.5:1 for large text** |
+| 1.4.7 | AAA | Low/no background audio | Speech recordings: background >=20dB quieter, or no background, or toggle |
+| 1.4.8 | **AAA** | **Visual presentation** | **User-selectable foreground/background colors; max 80 chars/line; no justified text; line-height >=1.5; paragraph spacing >=2x line-height; text resizable to 200%** |
+| 1.4.9 | AAA | Images of text (no exception) | Only use images of text for pure decoration or where essential |
+| 1.4.10 | AA | Reflow | No horizontal scroll at 320px CSS width (400% zoom) |
+| 1.4.11 | AA | Non-text contrast | UI components and graphical objects have 3:1 contrast |
+| 1.4.12 | AA | Text spacing | No loss of content when: line-height >=1.5x, paragraph spacing >=2x, letter-spacing >=0.12em, word-spacing >=0.16em |
+| 1.4.13 | AA | Content on hover/focus | Hoverable, dismissable, persistent tooltips/popovers |
+
+---
+
+## Operable
+
+### 2.1 Keyboard Accessible
+
+| SC | Level | Requirement | Implementation |
+|----|-------|-------------|----------------|
+| 2.1.1 | A | Keyboard | All functionality operable via keyboard |
+| 2.1.2 | A | No keyboard trap | Focus can always be moved away from any component |
+| 2.1.3 | AAA | Keyboard (no exception) | ALL functionality via keyboard with zero exceptions |
+| 2.1.4 | A | Character key shortcuts | Single-character shortcuts can be remapped or disabled |
+
+### 2.2 Enough Time
+
+| SC | Level | Requirement | Implementation |
+|----|-------|-------------|----------------|
+| 2.2.1 | A | Timing adjustable | Time limits can be turned off, adjusted, or extended |
+| 2.2.2 | A | Pause, stop, hide | Moving/blinking/scrolling content has pause/stop/hide controls |
+| 2.2.3 | AAA | No timing | No time limits at all (except real-time events) |
+| 2.2.4 | AAA | Interruptions | All non-emergency interruptions can be postponed or suppressed |
+| 2.2.5 | AAA | Re-authenticating | Data preserved when session expires and user re-authenticates |
+| 2.2.6 | AAA | Timeouts | Warn users about inactivity timeouts that cause data loss |
+
+### 2.3 Seizures and Physical Reactions
+
+| SC | Level | Requirement | Implementation |
+|----|-------|-------------|----------------|
+| 2.3.1 | A | Three flashes or below threshold | No content flashes >3 times/second |
+| 2.3.2 | AAA | Three flashes | No content flashes >3 times/second (no exceptions) |
+| 2.3.3 | AAA | Animation from interactions | Motion animation triggered by interaction can be disabled; respect `prefers-reduced-motion` |
+
+### 2.4 Navigable
+
+| SC | Level | Requirement | Implementation |
+|----|-------|-------------|----------------|
+| 2.4.1 | A | Bypass blocks | Skip-to-content link; ARIA landmarks |
+| 2.4.2 | A | Page titled | Descriptive, unique `<title>` per page |
+| 2.4.3 | A | Focus order | Tab order follows logical reading order |
+| 2.4.4 | A | Link purpose (in context) | Link text + context makes purpose clear |
+| 2.4.5 | AA | Multiple ways | At least two ways to find pages (nav, search, sitemap) |
+| 2.4.6 | AA | Headings and labels | Headings and labels describe topic/purpose |
+| 2.4.7 | AA | Focus visible | Keyboard focus indicator is visible |
+| 2.4.8 | AAA | Location | Breadcrumbs or other location indicator |
+| 2.4.9 | AAA | Link purpose (link only) | Link text alone makes purpose clear (no "click here") |
+| 2.4.10 | AAA | Section headings | Content organized with section headings |
+| 2.4.11 | AA | Focus not obscured (minimum) | Focused element not entirely hidden |
+| 2.4.12 | AAA | Focus not obscured (enhanced) | Focused element not even partially hidden |
+| 2.4.13 | AAA | Focus appearance | Focus indicator: >=2px outline, 3:1 contrast against unfocused state, encloses the component |
+
+### 2.5 Input Modalities
+
+| SC | Level | Requirement | Implementation |
+|----|-------|-------------|----------------|
+| 2.5.1 | A | Pointer gestures | Multi-point/path gestures have single-pointer alternatives |
+| 2.5.2 | A | Pointer cancellation | Actions fire on up-event, not down-event; can abort |
+| 2.5.3 | A | Label in name | Visible label is included in accessible name |
+| 2.5.4 | A | Motion actuation | Shake/tilt features have button alternatives; can be disabled |
+| 2.5.5 | AAA | Target size (enhanced) | Interactive targets >=44x44 CSS pixels |
+| 2.5.6 | AAA | Concurrent input mechanisms | Do not restrict to single input type (mouse, keyboard, touch) |
+| 2.5.7 | AA | Dragging movements | Drag-and-drop has single-pointer alternative |
+| 2.5.8 | AA | Target size (minimum) | Interactive targets >=24x24 CSS pixels |
+
+---
+
+## Understandable
+
+### 3.1 Readable
+
+| SC | Level | Requirement | Implementation |
+|----|-------|-------------|----------------|
+| 3.1.1 | A | Language of page | `<html lang="en">` (or appropriate language) |
+| 3.1.2 | AA | Language of parts | `lang` attribute on passages in different languages |
+| 3.1.3 | AAA | Unusual words | Glossary or inline definitions for jargon/idioms |
+| 3.1.4 | AAA | Abbreviations | Expand abbreviations on first use; provide `<abbr>` with `title` |
+| 3.1.5 | AAA | Reading level | Supplemental content or summaries when text exceeds lower secondary education level |
+| 3.1.6 | AAA | Pronunciation | Provide pronunciation guide for ambiguous words |
+
+### 3.2 Predictable
+
+| SC | Level | Requirement | Implementation |
+|----|-------|-------------|----------------|
+| 3.2.1 | A | On focus | No context change when element receives focus |
+| 3.2.2 | A | On input | No unexpected context change on input; warn users |
+| 3.2.3 | AA | Consistent navigation | Navigation order consistent across pages |
+| 3.2.4 | AA | Consistent identification | Same function = same label across pages |
+| 3.2.5 | AAA | Change on request | Context changes only when user explicitly requests them |
+| 3.2.6 | A | Consistent help | Help mechanisms in consistent location across pages |
+
+### 3.3 Input Assistance
+
+| SC | Level | Requirement | Implementation |
+|----|-------|-------------|----------------|
+| 3.3.1 | A | Error identification | Errors described in text, field identified |
+| 3.3.2 | A | Labels or instructions | All inputs have visible labels and instructions |
+| 3.3.3 | AA | Error suggestion | Provide correction suggestions when errors are detected |
+| 3.3.4 | AA | Error prevention (legal/financial/data) | Reversible, checked, or confirmed submissions |
+| 3.3.5 | AAA | Help | Context-sensitive help available for all inputs |
+| 3.3.6 | AAA | Error prevention (all) | ALL form submissions are reversible, checked, or confirmed |
+| 3.3.7 | A | Redundant entry | Auto-populate previously entered information |
+| 3.3.8 | AA | Accessible authentication (minimum) | No cognitive function test for login |
+| 3.3.9 | AAA | Accessible authentication (enhanced) | No object or user-content recognition for login |
+
+---
+
+## Robust
+
+| SC | Level | Requirement | Implementation |
+|----|-------|-------------|----------------|
+| 4.1.2 | A | Name, role, value | All UI components have accessible name, role, and state via ARIA or native HTML |
+| 4.1.3 | AA | Status messages | Status messages announced via `role="status"` or `aria-live` without focus change |
+
+---
+
+## AAA-Specific Design Implications
+
+These AAA criteria have the most significant impact on visual design and architecture decisions:
+
+### Contrast (1.4.6)
+Normal text: 7:1 minimum contrast ratio. Large text (>=18pt or >=14pt bold): 4.5:1 minimum. This eliminates most light grays, pastels, and low-contrast color combinations.
+
+### Visual Presentation (1.4.8)
+Maximum line width of 80 characters. No justified text alignment. Line-height >=1.5x font size. Paragraph spacing >=2x line-height. User-selectable foreground/background colors.
+
+### Target Size (2.5.5)
+All interactive elements must be at least 44x44 CSS pixels. This affects button sizing, link spacing, form controls, and navigation items.
+
+### Focus Appearance (2.4.13)
+Focus indicators must have >=2px solid outline with 3:1 contrast ratio against the unfocused state and against adjacent colors. The indicator must fully enclose the component.
+
+### No Timing (2.2.3)
+No time limits on any user interaction. Session timeouts must preserve data. Carousels and auto-advancing content must be user-controlled only.
+
+### Change on Request (3.2.5)
+No automatic context changes. All navigation, page loads, and state changes must be explicitly triggered by the user.

--- a/skills/accessibility/skill.yaml
+++ b/skills/accessibility/skill.yaml
@@ -18,4 +18,5 @@ provenance:
     - internal
     - wcag-aaa-accessibility
     - wcag-aa-accessibility
+    - wcag-aaa-web-design
   license: MIT

--- a/skills/accessibility/templates/base.html
+++ b/skills/accessibility/templates/base.html
@@ -1,0 +1,198 @@
+<!--
+  Base HTML5 Template
+  WCAG 2.2 AAA Compliant
+
+  Features:
+  - `lang` attribute for accessibility
+  - `color-scheme` meta tag for light/dark mode support
+  - Security meta tags (CSP, Referrer-Policy)
+  - Skip link for keyboard users
+  - ARIA live regions for screen reader announcements
+  - `noscript` fallback
+  - Logical document structure with ARIA landmarks
+
+  This file provides the foundational structure for all pages.
+-->
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="{{PAGE_DESCRIPTION}}" />
+  <meta name="color-scheme" content="light" />
+
+  <!--
+    SECURITY: HTTP Security Headers
+    These meta tags provide baseline security when HTTP headers cannot be set.
+    For production, configure these as HTTP response headers on your server
+    or reverse proxy instead. See references/security-error-handling.md.
+  -->
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+  <meta name="referrer" content="strict-origin-when-cross-origin" />
+
+  <!--
+    SECURITY: Content Security Policy (CSP)
+    This is a FALLBACK meta tag. For production, use an HTTP header instead,
+    which supports additional directives (frame-ancestors, report-uri).
+
+    Replace {{CSP_NONCE}} with a server-generated nonce for each request.
+    If serving static files without a server, remove the nonce and use
+    hash-based CSP or a permissive policy during development only.
+
+    See references/security-error-handling.md for full guidance.
+  -->
+  <!--
+  <meta http-equiv="Content-Security-Policy"
+    content="
+      default-src 'self';
+      script-src 'self' 'nonce-{{CSP_NONCE}}' 'strict-dynamic';
+      style-src 'self' 'unsafe-inline';
+      img-src 'self' data: https:;
+      font-src 'self';
+      object-src 'none';
+      base-uri 'none';
+      form-action 'self';
+    "
+  />
+  -->
+
+  <title>{{PAGE_TITLE}} — {{SITE_NAME}}</title>
+
+  <!-- Preconnect to external origins if needed -->
+  <!-- <link rel="preconnect" href="https://fonts.googleapis.com" /> -->
+
+  <!-- Stylesheets -->
+  <link rel="stylesheet" href="tokens.css" />
+  <link rel="stylesheet" href="responsive.css" />
+  <link rel="stylesheet" href="components.css" />
+  <link rel="stylesheet" href="styles.css" />
+
+  <noscript>
+    <style>
+      /* Ensure content is visible even without JavaScript */
+      [hidden] { display: block !important; }
+      .js-only { display: none !important; }
+      /* Show a noscript banner */
+      .noscript-banner { display: block !important; }
+    </style>
+  </noscript>
+</head>
+<body>
+  <!--
+    ACCESSIBILITY: Noscript Banner
+    Informs users that JavaScript is required for full functionality.
+    Hidden by default; shown via the <noscript> style rule above.
+  -->
+  <div class="noscript-banner alert alert--warning" role="alert" hidden>
+    <p>
+      This application requires JavaScript for full functionality.
+      Core content is available, but interactive features are disabled.
+    </p>
+  </div>
+
+  <!--
+    Skip Navigation Link (WCAG 2.4.1)
+    Must be the first focusable element on the page.
+  -->
+  <a href="#main-content" class="skip-link">
+    Skip to Main Content
+  </a>
+
+  <!--
+    Header Component
+    Replace with header.html content or framework equivalent.
+    Includes: logo, primary navigation, utility navigation.
+  -->
+  <header class="site-header">
+    <!-- See header.html template -->
+  </header>
+
+  <!--
+    Breadcrumb Navigation (WCAG 2.4.8 AAA - Location)
+    Provides location context within the site hierarchy.
+  -->
+  <nav aria-label="Breadcrumb">
+    <ol class="breadcrumb">
+      <li><a href="/">Home</a></li>
+      <li><a href="/section">Section</a></li>
+      <li><span aria-current="page">Current Page</span></li>
+    </ol>
+  </nav>
+
+  <!--
+    Main Content Area
+    The id="main-content" is the target of the skip link.
+    tabindex="-1" allows programmatic focus.
+  -->
+  <main id="main-content" tabindex="-1">
+    <!--
+      Page Heading (WCAG 2.4.10 AAA - Section Headings)
+      Every page must have an H1. Sections must use proper heading hierarchy.
+    -->
+    <h1>{{PAGE_HEADING}}</h1>
+
+    <!--
+      Content sections go here.
+      Each section should have a heading (h2, h3, etc.) for AAA compliance.
+      Text containers must use max-width: 80ch for line length (1.4.8).
+    -->
+    <section aria-labelledby="section-1-heading">
+      <h2 id="section-1-heading">Section Title</h2>
+      <div class="text-container">
+        <p>Content goes here.</p>
+      </div>
+    </section>
+  </main>
+
+  <!--
+    Footer Component
+    Replace with footer.html content or framework equivalent.
+  -->
+  <footer class="site-footer">
+    <!-- See footer.html template -->
+  </footer>
+
+  <!--
+    Back to Top Link (AAA best practice for long pages)
+  -->
+  <a href="#main-content" class="back-to-top" aria-label="Back to top of page">
+    Back to Top
+  </a>
+
+  <!--
+    Live Region for Status Messages (WCAG 4.1.3)
+    Use this region to announce dynamic status updates to screen readers.
+    SECURITY: Use textContent (not innerHTML) to inject text.
+    Example: document.getElementById('status-announcer').textContent = '...';
+  -->
+  <div
+    id="status-announcer"
+    role="status"
+    aria-live="polite"
+    aria-atomic="true"
+    class="sr-only"
+  ></div>
+
+  <!--
+    Alert Region for Urgent Messages
+    Use for error messages or time-sensitive notifications.
+    SECURITY: Use textContent (not innerHTML) to inject text.
+    Example: document.getElementById('alert-announcer').textContent = '...';
+  -->
+  <div
+    id="alert-announcer"
+    role="alert"
+    aria-live="assertive"
+    aria-atomic="true"
+    class="sr-only"
+  ></div>
+
+  <!--
+    Scripts
+    SECURITY: Add nonce="{{CSP_NONCE}}" when using a nonce-based CSP.
+    The defer attribute ensures scripts run after the DOM is parsed.
+  -->
+  <script src="main.js" defer></script>
+</body>
+</html>
+

--- a/skills/accessibility/templates/check_contrast.py
+++ b/skills/accessibility/templates/check_contrast.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""
+WCAG 2.2 AAA Color Contrast Checker
+
+Validates foreground/background color pairs against WCAG 2.2 contrast requirements.
+
+Usage:
+    python3 check_contrast.py <foreground_hex> <background_hex>
+    python3 check_contrast.py --file <colors_json>
+    python3 check_contrast.py --tokens <tokens_css_file>
+    python3 check_contrast.py --file <colors_json> --json
+
+Examples:
+    python3 check_contrast.py "#1a365d" "#ffffff"
+    python3 check_contrast.py --file colors.json
+    python3 check_contrast.py --tokens templates/tokens.css
+    python3 check_contrast.py --file colors.json --json > report.json
+
+colors.json format:
+    {
+      "pairs": [
+        {"name": "Primary on White", "fg": "#1a365d", "bg": "#ffffff"},
+        {"name": "Body Text", "fg": "#1a1a1a", "bg": "#f5f5f5"}
+      ]
+    }
+
+Exit codes:
+    0 = all pairs pass AAA
+    1 = one or more pairs fail AAA
+    2 = invalid input
+"""
+
+import sys
+import json
+import re
+
+
+# Maximum file size for input files (1 MB)
+MAX_FILE_SIZE = 1_048_576
+
+
+def hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
+    """Convert hex color string to RGB tuple.
+
+    Accepts 3-digit or 6-digit hex strings with or without a leading '#'.
+    Validates that the input contains only valid hexadecimal characters.
+    """
+    hex_color = hex_color.strip().lstrip("#")
+    if len(hex_color) == 3:
+        hex_color = "".join(c * 2 for c in hex_color)
+    if len(hex_color) != 6 or not re.fullmatch(r"[0-9a-fA-F]{6}", hex_color):
+        raise ValueError(f"Invalid hex color: #{hex_color}")
+    return (
+        int(hex_color[0:2], 16),
+        int(hex_color[2:4], 16),
+        int(hex_color[4:6], 16),
+    )
+
+
+def rgb_to_hex(r: int, g: int, b: int) -> str:
+    """Convert RGB tuple to hex color string."""
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def relative_luminance(r: int, g: int, b: int) -> float:
+    """Calculate relative luminance per WCAG 2.2 definition."""
+    def linearize(channel: int) -> float:
+        srgb = channel / 255.0
+        if srgb <= 0.04045:
+            return srgb / 12.92
+        return ((srgb + 0.055) / 1.055) ** 2.4
+
+    r_lin = linearize(r)
+    g_lin = linearize(g)
+    b_lin = linearize(b)
+    return 0.2126 * r_lin + 0.7152 * g_lin + 0.0722 * b_lin
+
+
+def contrast_ratio(fg_hex: str, bg_hex: str) -> float:
+    """Calculate contrast ratio between two hex colors."""
+    fg_rgb = hex_to_rgb(fg_hex)
+    bg_rgb = hex_to_rgb(bg_hex)
+    lum_fg = relative_luminance(*fg_rgb)
+    lum_bg = relative_luminance(*bg_rgb)
+    lighter = max(lum_fg, lum_bg)
+    darker = min(lum_fg, lum_bg)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def suggest_aaa_color(fg_hex: str, bg_hex: str) -> str:
+    """Suggest the closest AAA-compliant foreground color by darkening or lightening."""
+    bg_rgb = hex_to_rgb(bg_hex)
+    bg_lum = relative_luminance(*bg_rgb)
+
+    # Try darkening the foreground (reducing each channel)
+    best = None
+    for step in range(256):
+        r, g, b = hex_to_rgb(fg_hex)
+        # Darken proportionally
+        factor = max(0, 1.0 - step * 0.005)
+        nr, ng, nb = int(r * factor), int(g * factor), int(b * factor)
+        nr, ng, nb = max(0, nr), max(0, ng), max(0, nb)
+        candidate = rgb_to_hex(nr, ng, nb)
+        ratio = contrast_ratio(candidate, bg_hex)
+        if ratio >= 7.0:
+            best = candidate
+            break
+
+    if best is None:
+        # Try lightening instead (for dark backgrounds)
+        for step in range(256):
+            r, g, b = hex_to_rgb(fg_hex)
+            factor = min(2.0, 1.0 + step * 0.005)
+            nr = min(255, int(r * factor))
+            ng = min(255, int(g * factor))
+            nb = min(255, int(b * factor))
+            candidate = rgb_to_hex(nr, ng, nb)
+            ratio = contrast_ratio(candidate, bg_hex)
+            if ratio >= 7.0:
+                best = candidate
+                break
+
+    return best or "#000000"
+
+
+def evaluate_pair(name: str, fg: str, bg: str) -> dict:
+    """Evaluate a color pair against all WCAG contrast levels."""
+    ratio = contrast_ratio(fg, bg)
+    result = {
+        "name": name,
+        "fg": fg,
+        "bg": bg,
+        "ratio": round(ratio, 2),
+        "aa_normal": ratio >= 4.5,
+        "aa_large": ratio >= 3.0,
+        "aaa_normal": ratio >= 7.0,
+        "aaa_large": ratio >= 4.5,
+        "ui_component": ratio >= 3.0,
+    }
+    if not result["aaa_normal"]:
+        result["suggestion"] = suggest_aaa_color(fg, bg)
+    return result
+
+
+def print_result(result: dict) -> None:
+    """Print formatted result for a single color pair."""
+    status_aaa_normal = "PASS" if result["aaa_normal"] else "FAIL"
+    status_aaa_large = "PASS" if result["aaa_large"] else "FAIL"
+    status_aa_normal = "PASS" if result["aa_normal"] else "FAIL"
+    status_ui = "PASS" if result["ui_component"] else "FAIL"
+
+    print(f"\n  {result['name']}")
+    print(f"  Foreground: {result['fg']}  Background: {result['bg']}")
+    print(f"  Contrast Ratio: {result['ratio']}:1")
+    print(f"  -----------------------------------------------")
+    print(f"  AAA Normal Text (>=7:1)    : {status_aaa_normal}")
+    print(f"  AAA Large Text  (>=4.5:1)  : {status_aaa_large}")
+    print(f"  AA Normal Text  (>=4.5:1)  : {status_aa_normal}")
+    print(f"  UI Components   (>=3:1)    : {status_ui}")
+
+    if "suggestion" in result:
+        suggested_ratio = contrast_ratio(result["suggestion"], result["bg"])
+        print(f"  Suggested Fix: {result['suggestion']} ({round(suggested_ratio, 2)}:1)")
+
+
+def extract_tokens_from_css(filepath: str) -> list[dict]:
+    """Extract color token pairs from a CSS custom properties file."""
+    with open(filepath, "r") as f:
+        content = f.read()
+
+    # Extract all --color-* custom properties
+    pattern = r"--(color-[\w-]+)\s*:\s*(#[0-9a-fA-F]{3,8})"
+    tokens = dict(re.findall(pattern, content))
+
+    if not tokens:
+        return []
+
+    # Determine background colors
+    bg_colors = {}
+    for name, value in tokens.items():
+        if "bg" in name and "bg-" not in name:
+            bg_colors["default"] = value
+        elif name == "color-bg":
+            bg_colors["default"] = value
+        elif name == "color-bg-alt":
+            bg_colors["alt"] = value
+        elif name == "color-bg-dark":
+            bg_colors["dark"] = value
+
+    if "default" not in bg_colors:
+        bg_colors["default"] = "#ffffff"
+
+    # Build pairs: every non-bg color against default bg
+    pairs = []
+    for name, value in tokens.items():
+        if "bg" in name:
+            continue
+        pairs.append({
+            "name": f"--{name} on default bg",
+            "fg": value,
+            "bg": bg_colors["default"],
+        })
+        # Also test against alt bg if available
+        if "alt" in bg_colors:
+            pairs.append({
+                "name": f"--{name} on alt bg",
+                "fg": value,
+                "bg": bg_colors["alt"],
+            })
+
+    return pairs
+
+
+def main():
+    args = sys.argv[1:]
+    json_output = "--json" in args
+    if json_output:
+        args.remove("--json")
+
+    if len(args) < 2:
+        print("Usage:")
+        print("  python3 check_contrast.py <foreground_hex> <background_hex>")
+        print('  python3 check_contrast.py --file <colors_json> [--json]')
+        print('  python3 check_contrast.py --tokens <tokens_css_file> [--json]')
+        sys.exit(2)
+
+    pairs_to_check = []
+
+    if args[0] == "--file":
+        filepath = args[1]
+        try:
+            import os
+            if os.path.getsize(filepath) > MAX_FILE_SIZE:
+                print(f"Error: File exceeds maximum size of {MAX_FILE_SIZE} bytes.", file=sys.stderr)
+                sys.exit(2)
+            with open(filepath, "r") as f:
+                data = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError, OSError) as e:
+            print(f"Error reading file: {e}", file=sys.stderr)
+            sys.exit(2)
+
+        pairs_to_check = data.get("pairs", [])
+        if not pairs_to_check:
+            print("No color pairs found in file.", file=sys.stderr)
+            sys.exit(2)
+
+    elif args[0] == "--tokens":
+        filepath = args[1]
+        try:
+            pairs_to_check = extract_tokens_from_css(filepath)
+        except FileNotFoundError:
+            print(f"Error: File not found: {filepath}", file=sys.stderr)
+            sys.exit(2)
+
+        if not pairs_to_check:
+            print("No color tokens found in CSS file.", file=sys.stderr)
+            sys.exit(2)
+
+    else:
+        fg = args[0]
+        bg = args[1]
+        pairs_to_check = [{"name": f"{fg} on {bg}", "fg": fg, "bg": bg}]
+
+    # Evaluate all pairs
+    results = []
+    all_pass = True
+    for pair in pairs_to_check:
+        try:
+            result = evaluate_pair(
+                pair.get("name", f"{pair['fg']} on {pair['bg']}"),
+                pair["fg"],
+                pair["bg"],
+            )
+            results.append(result)
+            if not result["aaa_normal"]:
+                all_pass = False
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(2)
+
+    # Output
+    if json_output:
+        output = {
+            "standard": "WCAG 2.2 AAA",
+            "pass": all_pass,
+            "total": len(results),
+            "failures": sum(1 for r in results if not r["aaa_normal"]),
+            "results": results,
+        }
+        print(json.dumps(output, indent=2))
+    else:
+        print("=" * 50)
+        print("  WCAG 2.2 AAA Contrast Audit")
+        print("=" * 50)
+
+        for result in results:
+            print_result(result)
+
+        print(f"\n{'=' * 50}")
+        total = len(results)
+        failures = sum(1 for r in results if not r["aaa_normal"])
+        if all_pass:
+            print(f"  RESULT: PASS - All {total} pairs meet WCAG AAA.")
+        else:
+            print(f"  RESULT: FAIL - {failures}/{total} pairs fail WCAG AAA.")
+        print(f"{'=' * 50}")
+
+    sys.exit(0 if all_pass else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/accessibility/templates/components.css
+++ b/skills/accessibility/templates/components.css
@@ -1,0 +1,698 @@
+/*
+ * Corporate Web Application Component Styles
+ * WCAG 2.2 AAA Compliant
+ *
+ * This file provides styles for enterprise-grade components:
+ * - Data Tables (sorting, density, bulk actions)
+ * - Empty States
+ * - Loading / Skeleton Screens
+ * - Sidebar Navigation
+ * - Notification Toasts
+ * - Status Badges
+ *
+ * Requires: tokens.css (must be loaded first)
+ */
+
+/* ========================================
+   DATA TABLE
+   ======================================== */
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+.data-table__caption {
+  font-weight: var(--font-bold);
+  font-size: var(--text-lg);
+  text-align: start;
+  margin-block-end: var(--space-3);
+  color: var(--color-text);
+}
+
+.data-table__head th {
+  position: sticky;
+  top: 0;
+  z-index: var(--z-sticky);
+  background-color: var(--color-bg-alt);
+  font-weight: var(--font-semibold);
+  font-size: var(--text-sm);
+  padding: var(--space-3) var(--space-4);
+  border-block-end: 2px solid var(--color-border);
+  text-align: start;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+/* Numeric columns: right-align */
+.data-table__cell--numeric {
+  text-align: end;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Checkbox column: fixed narrow width */
+.data-table__cell--checkbox {
+  width: var(--target-size-min);
+  text-align: center;
+}
+
+/* Actions column: right-aligned, no wrap */
+.data-table__cell--actions {
+  text-align: end;
+  white-space: nowrap;
+}
+
+.data-table__body td {
+  padding: var(--space-3) var(--space-4);
+  border-block-end: 1px solid var(--color-border-light);
+  vertical-align: middle;
+  color: var(--color-text);
+}
+
+/* Row hover */
+.data-table__body tr:hover {
+  background-color: var(--color-bg-alt);
+}
+
+/* Selected row */
+.data-table__body tr[aria-selected="true"] {
+  background-color: var(--color-info-bg);
+}
+
+/* Sort button in header */
+.data-table__sort-btn {
+  all: unset;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-weight: var(--font-semibold);
+  font-size: var(--text-sm);
+  color: var(--color-text);
+  min-height: var(--target-size-min);
+}
+
+.data-table__sort-btn:focus-visible {
+  outline: var(--focus-outline-width) solid var(--color-focus);
+  outline-offset: var(--focus-outline-offset);
+  border-radius: var(--radius-sm);
+}
+
+.data-table__sort-icon::after {
+  content: "\2195"; /* up-down arrow */
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+[aria-sort="ascending"] .data-table__sort-icon::after {
+  content: "\2191"; /* up arrow */
+  color: var(--color-primary);
+}
+
+[aria-sort="descending"] .data-table__sort-icon::after {
+  content: "\2193"; /* down arrow */
+  color: var(--color-primary);
+}
+
+/* Display density variants */
+.data-table--compact .data-table__body td,
+.data-table--compact .data-table__head th {
+  padding-block: var(--space-1);
+  font-size: var(--text-sm);
+}
+
+.data-table--spacious .data-table__body td,
+.data-table--spacious .data-table__head th {
+  padding-block: var(--space-4);
+}
+
+/* ========================================
+   TABLE TOOLBAR (Bulk Actions)
+   ======================================== */
+
+.table-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  background-color: var(--color-info-bg);
+  border: 1px solid var(--color-info);
+  border-radius: var(--radius-md);
+  margin-block-end: var(--space-3);
+}
+
+.table-toolbar__count {
+  font-weight: var(--font-semibold);
+  color: var(--color-text);
+}
+
+.table-toolbar__actions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+/* ========================================
+   TABLE PAGINATION
+   ======================================== */
+
+.table-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-4) 0;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.table-pagination__info {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.table-pagination__controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.table-pagination__label {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.table-pagination__select {
+  min-height: 36px;
+  min-width: auto;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-sm);
+}
+
+.table-pagination__page {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  min-height: 36px;
+  font-size: var(--text-sm);
+  border-radius: var(--radius-md);
+  color: var(--color-text-muted);
+}
+
+.table-pagination__page[aria-current="page"] {
+  background-color: var(--color-primary);
+  color: var(--color-text-inverse);
+  font-weight: var(--font-semibold);
+}
+
+/* ========================================
+   EMPTY STATES
+   ======================================== */
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  max-width: 480px;
+  padding: var(--space-8) var(--space-6);
+}
+
+.empty-state__image {
+  max-width: 200px;
+  margin-block-end: var(--space-5);
+}
+
+.empty-state__title {
+  font-size: var(--text-xl);
+  font-weight: var(--font-bold);
+  color: var(--color-text);
+  margin-block-end: var(--space-3);
+}
+
+.empty-state__body {
+  font-size: var(--text-base);
+  color: var(--color-text-muted);
+  line-height: var(--leading-normal);
+  margin-block-end: var(--space-5);
+}
+
+.empty-state__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.empty-state__link {
+  font-size: var(--text-sm);
+}
+
+/* Error variant */
+.empty-state--error .empty-state__title {
+  color: var(--color-error);
+}
+
+/* ========================================
+   LOADING / SKELETON SCREENS
+   ======================================== */
+
+.skeleton {
+  background-color: var(--color-skeleton);
+  border-radius: var(--radius-md);
+  position: relative;
+  overflow: hidden;
+}
+
+.skeleton::after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0;
+  inset-inline-start: -150%;
+  height: 100%;
+  width: 150%;
+  background: linear-gradient(
+    to right,
+    transparent 0%,
+    var(--color-skeleton-highlight) 50%,
+    transparent 100%
+  );
+  animation: skeleton-shimmer 1.5s infinite;
+}
+
+@keyframes skeleton-shimmer {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(200%); }
+}
+
+/* Respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .skeleton::after {
+    animation: none;
+  }
+}
+
+/* Skeleton variants */
+.skeleton--text {
+  height: 1rem;
+  margin-block-end: var(--space-2);
+}
+
+.skeleton--text-lg {
+  height: 1.5rem;
+  width: 60%;
+  margin-block-end: var(--space-3);
+}
+
+.skeleton--heading {
+  height: 2rem;
+  width: 40%;
+  margin-block-end: var(--space-4);
+}
+
+.skeleton--avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+}
+
+.skeleton--card {
+  height: 200px;
+  width: 100%;
+}
+
+.skeleton--table-row {
+  height: 48px;
+  width: 100%;
+  margin-block-end: var(--space-1);
+}
+
+/* ========================================
+   SIDEBAR NAVIGATION
+   ======================================== */
+
+.sidebar {
+  position: fixed;
+  top: 0;
+  inset-inline-start: 0;
+  width: 260px;
+  height: 100vh;
+  background-color: var(--color-bg);
+  border-inline-end: 1px solid var(--color-border-light);
+  display: flex;
+  flex-direction: column;
+  z-index: var(--z-overlay);
+  overflow-y: auto;
+  transition: transform var(--transition-normal);
+}
+
+.sidebar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-4);
+  border-block-end: 1px solid var(--color-border-light);
+}
+
+.sidebar__brand {
+  font-weight: var(--font-bold);
+  font-size: var(--text-lg);
+  color: var(--color-text);
+}
+
+.sidebar__close {
+  all: unset;
+  cursor: pointer;
+  min-width: var(--target-size-min);
+  min-height: var(--target-size-min);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md);
+  color: var(--color-text-muted);
+}
+
+.sidebar__close:focus-visible {
+  outline: var(--focus-outline-width) solid var(--color-focus);
+  outline-offset: var(--focus-outline-offset);
+}
+
+.sidebar__nav {
+  list-style: none;
+  padding: var(--space-3) 0;
+}
+
+.sidebar__link {
+  all: unset;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--text-base);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  min-height: var(--target-size-min);
+  width: 100%;
+  text-decoration: none;
+  border-radius: 0;
+}
+
+.sidebar__link:hover {
+  background-color: var(--color-bg-alt);
+  color: var(--color-text);
+}
+
+.sidebar__link:focus-visible {
+  outline: var(--focus-outline-width) solid var(--color-focus);
+  outline-offset: calc(-1 * var(--focus-outline-offset));
+}
+
+.sidebar__item--active .sidebar__link {
+  color: var(--color-primary);
+  font-weight: var(--font-semibold);
+  background-color: var(--color-info-bg);
+  border-inline-start: 3px solid var(--color-primary);
+}
+
+.sidebar__icon {
+  flex-shrink: 0;
+}
+
+.sidebar__label {
+  flex: 1;
+}
+
+.sidebar__chevron {
+  flex-shrink: 0;
+  transition: transform var(--transition-fast);
+}
+
+[aria-expanded="true"] .sidebar__chevron {
+  transform: rotate(180deg);
+}
+
+.sidebar__subnav {
+  list-style: none;
+  padding: 0;
+}
+
+.sidebar__sublink {
+  display: flex;
+  align-items: center;
+  padding: var(--space-2) var(--space-4);
+  padding-inline-start: calc(var(--space-4) + 20px + var(--space-3));
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  text-decoration: none;
+  min-height: var(--target-size-min);
+}
+
+.sidebar__sublink:hover {
+  background-color: var(--color-bg-alt);
+  color: var(--color-text);
+}
+
+.sidebar__sublink:focus-visible {
+  outline: var(--focus-outline-width) solid var(--color-focus);
+  outline-offset: calc(-1 * var(--focus-outline-offset));
+}
+
+/* Sidebar overlay for mobile */
+.sidebar-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: calc(var(--z-overlay) - 1);
+}
+
+/* Sidebar toggle button */
+.sidebar-toggle {
+  all: unset;
+  cursor: pointer;
+  min-width: var(--target-size-min);
+  min-height: var(--target-size-min);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+}
+
+.sidebar-toggle:focus-visible {
+  outline: var(--focus-outline-width) solid var(--color-focus);
+  outline-offset: var(--focus-outline-offset);
+}
+
+/* ========================================
+   NOTIFICATION TOASTS
+   ======================================== */
+
+.toast-container {
+  position: fixed;
+  top: var(--space-4);
+  inset-inline-end: var(--space-4);
+  z-index: var(--z-toast);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-width: 420px;
+  width: 100%;
+}
+
+.toast {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 2px solid;
+  border-radius: var(--radius-md);
+  background-color: var(--color-bg);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.toast--error {
+  border-color: var(--color-error);
+}
+
+.toast--success {
+  border-color: var(--color-success);
+}
+
+.toast--warning {
+  border-color: var(--color-warning);
+}
+
+.toast--info {
+  border-color: var(--color-info);
+}
+
+.toast__content {
+  flex: 1;
+}
+
+.toast__title {
+  font-weight: var(--font-semibold);
+  font-size: var(--text-base);
+  color: var(--color-text);
+  margin-block-end: var(--space-1);
+}
+
+.toast__message {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  line-height: var(--leading-normal);
+}
+
+.toast__close {
+  all: unset;
+  cursor: pointer;
+  min-width: var(--target-size-min);
+  min-height: var(--target-size-min);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+.toast__close:focus-visible {
+  outline: var(--focus-outline-width) solid var(--color-focus);
+  outline-offset: var(--focus-outline-offset);
+  border-radius: var(--radius-sm);
+}
+
+/* ========================================
+   STATUS BADGES
+   ======================================== */
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  border-radius: var(--radius-md);
+  white-space: nowrap;
+}
+
+/* Status uses both color AND a text label — never color alone (1.4.1) */
+.status-badge--success {
+  background-color: var(--color-success-bg);
+  color: var(--color-success);
+}
+
+.status-badge--error {
+  background-color: var(--color-error-bg);
+  color: var(--color-error);
+}
+
+.status-badge--warning {
+  background-color: var(--color-warning-bg);
+  color: var(--color-warning);
+}
+
+.status-badge--info {
+  background-color: var(--color-info-bg);
+  color: var(--color-info);
+}
+
+/* Dot indicator before text for additional visual cue */
+.status-badge::before {
+  content: '';
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: currentColor;
+  flex-shrink: 0;
+}
+
+/* ========================================
+   BUTTON VARIANTS (extends tokens.css .btn)
+   ======================================== */
+
+.btn--primary {
+  background-color: var(--color-primary);
+  color: var(--color-text-inverse);
+  border-color: var(--color-primary);
+}
+
+.btn--primary:hover {
+  background-color: var(--color-primary-dark);
+  border-color: var(--color-primary-dark);
+}
+
+.btn--secondary {
+  background-color: transparent;
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.btn--secondary:hover {
+  background-color: var(--color-info-bg);
+}
+
+.btn--danger {
+  background-color: var(--color-error);
+  color: var(--color-text-inverse);
+  border-color: var(--color-error);
+}
+
+.btn--ghost {
+  background-color: transparent;
+  color: var(--color-primary);
+  border-color: transparent;
+}
+
+.btn--ghost:hover {
+  background-color: var(--color-bg-alt);
+}
+
+.btn--sm {
+  min-height: 36px;
+  min-width: 36px;
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-sm);
+}
+
+/* ========================================
+   RESPONSIVE SIDEBAR BEHAVIOR
+   ======================================== */
+
+/* Mobile: sidebar is hidden off-screen by default */
+@media (max-width: 767px) {
+  .sidebar {
+    transform: translateX(-100%);
+  }
+
+  .sidebar[aria-hidden="false"],
+  .sidebar.is-open {
+    transform: translateX(0);
+  }
+
+  .sidebar-toggle {
+    display: inline-flex;
+  }
+}
+
+/* Tablet and above: sidebar is visible, toggle is hidden */
+@media (min-width: 768px) {
+  .sidebar {
+    position: sticky;
+    transform: none;
+  }
+
+  .sidebar-toggle {
+    display: none;
+  }
+
+  .sidebar__close {
+    display: none;
+  }
+
+  .sidebar-overlay {
+    display: none;
+  }
+}

--- a/skills/accessibility/templates/data-table.html
+++ b/skills/accessibility/templates/data-table.html
@@ -1,0 +1,133 @@
+<!--
+  Accessible Data Table Template
+  WCAG 2.2 AAA Compliant
+
+  Features:
+  - Proper <caption> for screen readers
+  - Sortable column headers with aria-sort
+  - Sticky header on scroll
+  - Row-level actions revealed on hover/focus
+  - Responsive wrapper for horizontal scroll
+  - Tabular numerals for numeric columns
+  - Bulk action toolbar (shown on selection)
+
+  Replace placeholder content with actual data.
+  All classes reference `tokens.css` and `components.css` for styling.
+-->
+
+<!-- Bulk Action Toolbar — shown when rows are selected -->
+<div class="table-toolbar" role="toolbar" aria-label="Table actions" hidden>
+  <span class="table-toolbar__count" aria-live="polite">
+    <span class="table-toolbar__count-number">0</span> items selected
+  </span>
+  <div class="table-toolbar__actions">
+    <button type="button" class="btn btn--secondary btn--sm">Export</button>
+    <button type="button" class="btn btn--danger btn--sm">Delete</button>
+  </div>
+</div>
+
+<!-- Responsive wrapper preserves table semantics for screen readers -->
+<div class="table-responsive" role="region" aria-label="Data table" tabindex="0">
+  <table class="data-table">
+    <caption class="data-table__caption">
+      Quarterly Performance Report
+      <!-- Optional: add a brief description for complex tables -->
+      <span class="sr-only">
+        Sortable table. Use column headers to sort. Select rows for bulk actions.
+      </span>
+    </caption>
+    <thead class="data-table__head">
+      <tr>
+        <!-- Select-all checkbox -->
+        <th scope="col" class="data-table__cell--checkbox">
+          <label class="sr-only" for="select-all">Select all rows</label>
+          <input type="checkbox" id="select-all" aria-label="Select all rows" />
+        </th>
+        <!-- Text column: left-aligned (default) -->
+        <th scope="col" aria-sort="none">
+          <button type="button" class="data-table__sort-btn">
+            Name
+            <span class="data-table__sort-icon" aria-hidden="true"></span>
+          </button>
+        </th>
+        <!-- Text column -->
+        <th scope="col" aria-sort="none">
+          <button type="button" class="data-table__sort-btn">
+            Department
+            <span class="data-table__sort-icon" aria-hidden="true"></span>
+          </button>
+        </th>
+        <!-- Numeric column: right-aligned -->
+        <th scope="col" class="data-table__cell--numeric" aria-sort="none">
+          <button type="button" class="data-table__sort-btn">
+            Revenue
+            <span class="data-table__sort-icon" aria-hidden="true"></span>
+          </button>
+        </th>
+        <!-- Date column: left-aligned (qualitative number) -->
+        <th scope="col" aria-sort="descending">
+          <button type="button" class="data-table__sort-btn">
+            Date
+            <span class="data-table__sort-icon" aria-hidden="true"></span>
+          </button>
+        </th>
+        <!-- Status column -->
+        <th scope="col">Status</th>
+        <!-- Actions column (no sort) -->
+        <th scope="col" class="data-table__cell--actions">
+          <span class="sr-only">Actions</span>
+        </th>
+      </tr>
+    </thead>
+    <tbody class="data-table__body">
+      <tr>
+        <td class="data-table__cell--checkbox">
+          <label class="sr-only" for="row-1">Select row 1</label>
+          <input type="checkbox" id="row-1" aria-label="Select Acme Corporation" />
+        </td>
+        <td>Acme Corporation</td>
+        <td>Engineering</td>
+        <td class="data-table__cell--numeric">$1,234,567.89</td>
+        <td>2026-01-15</td>
+        <td>
+          <!-- Status uses both color AND text — never color alone (1.4.1) -->
+          <span class="status-badge status-badge--success">Active</span>
+        </td>
+        <td class="data-table__cell--actions">
+          <button type="button" class="btn btn--ghost btn--sm" aria-label="Edit Acme Corporation">
+            Edit
+          </button>
+          <button type="button" class="btn btn--ghost btn--sm btn--danger" aria-label="Delete Acme Corporation">
+            Delete
+          </button>
+        </td>
+      </tr>
+      <!-- Additional rows follow the same pattern -->
+    </tbody>
+  </table>
+</div>
+
+<!-- Pagination -->
+<nav class="table-pagination" aria-label="Table pagination">
+  <div class="table-pagination__info" aria-live="polite">
+    Showing 1-10 of 42 results
+  </div>
+  <div class="table-pagination__controls">
+    <label for="rows-per-page" class="table-pagination__label">Rows per page:</label>
+    <select id="rows-per-page" class="table-pagination__select">
+      <option value="10" selected>10</option>
+      <option value="25">25</option>
+      <option value="50">50</option>
+      <option value="100">100</option>
+    </select>
+    <button type="button" class="btn btn--ghost btn--sm" aria-label="Previous page" disabled>
+      Previous
+    </button>
+    <span class="table-pagination__page" aria-current="page">1</span>
+    <span class="table-pagination__page">2</span>
+    <span class="table-pagination__page">3</span>
+    <button type="button" class="btn btn--ghost btn--sm" aria-label="Next page">
+      Next
+    </button>
+  </div>
+</nav>

--- a/skills/accessibility/templates/empty-state.html
+++ b/skills/accessibility/templates/empty-state.html
@@ -1,0 +1,60 @@
+<!--
+  Empty State Templates
+  WCAG 2.2 AAA Compliant
+
+  Three variants for different contexts:
+  1. No Data (First Use)
+  2. No Results (Search/Filter)
+  3. Error State (System/Permission)
+
+  Replace placeholder content with actual text and actions.
+  All classes reference `tokens.css` and `components.css` for styling.
+-->
+
+<!-- ============================================
+     VARIANT 1: No Data (First Use)
+     ============================================ -->
+<div class="empty-state" role="status">
+  <!-- Optional: simple, non-decorative illustration -->
+  <!-- <img src="illustration.svg" alt="" class="empty-state__image" aria-hidden="true" /> -->
+  <h2 class="empty-state__title">No projects yet</h2>
+  <p class="empty-state__body">
+    Projects help you organize your work into manageable units.
+    Create your first project to get started.
+  </p>
+  <div class="empty-state__actions">
+    <button type="button" class="btn btn--primary">Create Project</button>
+    <a href="/docs/projects" class="empty-state__link">Learn more about projects</a>
+  </div>
+</div>
+
+
+<!-- ============================================
+     VARIANT 2: No Results (Search/Filter)
+     ============================================ -->
+<div class="empty-state" role="status" aria-live="polite">
+  <h2 class="empty-state__title">No results found</h2>
+  <p class="empty-state__body">
+    Your search for "<strong>quarterly report</strong>" did not match any records.
+    Try adjusting your search terms or removing filters.
+  </p>
+  <div class="empty-state__actions">
+    <button type="button" class="btn btn--secondary">Clear All Filters</button>
+  </div>
+</div>
+
+
+<!-- ============================================
+     VARIANT 3: Error State (System/Permission)
+     ============================================ -->
+<div class="empty-state empty-state--error" role="alert">
+  <h2 class="empty-state__title">Unable to load data</h2>
+  <p class="empty-state__body">
+    An error occurred while retrieving the requested information.
+    This may be a temporary issue. If the problem persists, please contact support.
+  </p>
+  <div class="empty-state__actions">
+    <button type="button" class="btn btn--primary">Retry</button>
+    <a href="/support" class="empty-state__link">Contact support</a>
+  </div>
+</div>

--- a/skills/accessibility/templates/footer.html
+++ b/skills/accessibility/templates/footer.html
@@ -1,0 +1,108 @@
+<!--
+  Accessible Footer Component
+  WCAG 2.2 AAA Compliant
+
+  Requirements met:
+  - 2.4.9  Link Purpose (link only) — all links self-descriptive
+  - 2.4.10 Section Headings — footer sections have headings
+  - 2.5.5  Target Size (enhanced) — 44x44px minimum
+  - 1.3.1  Info and Relationships — semantic structure
+  - 3.2.3  Consistent Navigation — same footer across pages
+
+  Security:
+  - External links use rel="noopener noreferrer" and target="_blank"
+  - Year is set via textContent (not innerHTML) to prevent XSS
+
+  Responsive behavior:
+  - sm: Single column, stacked sections
+  - md: 2-column grid
+  - lg+: Multi-column layout
+-->
+
+<footer class="site-footer">
+  <div class="footer-container">
+    <!-- Footer Navigation Sections -->
+    <div class="footer-grid">
+      <!-- Column 1: Company Info -->
+      <div class="footer-section">
+        <h2 class="footer-heading">{{SITE_NAME}}</h2>
+        <p class="footer-description">
+          {{SITE_DESCRIPTION}}
+        </p>
+      </div>
+
+      <!-- Column 2: Navigation Links -->
+      <nav aria-label="Footer Navigation">
+        <h2 class="footer-heading">Navigation</h2>
+        <ul class="footer-links" role="list">
+          <li><a href="/about">About Us</a></li>
+          <li><a href="/services">Services</a></li>
+          <li><a href="/resources">Resources</a></li>
+          <li><a href="/contact">Contact Us</a></li>
+        </ul>
+      </nav>
+
+      <!-- Column 3: Legal Links -->
+      <nav aria-label="Legal Information">
+        <h2 class="footer-heading">Legal</h2>
+        <ul class="footer-links" role="list">
+          <li><a href="/privacy">Privacy Policy</a></li>
+          <li><a href="/terms">Terms of Service</a></li>
+          <li><a href="/accessibility">Accessibility Statement</a></li>
+          <li><a href="/cookies">Cookie Policy</a></li>
+        </ul>
+      </nav>
+
+      <!--
+        Column 4: Contact Information
+        NOTE: The <address> element is semantically for the contact info
+        of the document or article author. For general company contact
+        details, use a plain <div> to avoid confusing assistive technologies.
+      -->
+      <div class="footer-section">
+        <h2 class="footer-heading">Contact</h2>
+        <div class="footer-contact">
+          <p>
+            <a href="mailto:{{CONTACT_EMAIL}}">{{CONTACT_EMAIL}}</a>
+          </p>
+          <p>
+            <a href="tel:{{CONTACT_PHONE}}">{{CONTACT_PHONE}}</a>
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Footer Bottom Bar -->
+    <div class="footer-bottom">
+      <p>
+        &copy; <span id="footer-year">2026</span> {{SITE_NAME}}.
+        All rights reserved.
+      </p>
+    </div>
+  </div>
+</footer>
+
+<!--
+  EXTERNAL LINK PATTERN:
+  When linking to external websites, always include rel="noopener noreferrer"
+  to prevent the target page from accessing window.opener. Add a visual
+  indicator and screen reader text to inform users the link opens externally.
+
+  Example:
+    <a href="https://example.com"
+       target="_blank"
+       rel="noopener noreferrer">
+      Example Site
+      <span class="sr-only">(opens in a new tab)</span>
+    </a>
+-->
+
+<!--
+  Footer year auto-update (include in main.js):
+  SECURITY: Use textContent, not innerHTML.
+
+  const yearEl = document.getElementById('footer-year');
+  if (yearEl) {
+    yearEl.textContent = new Date().getFullYear().toString();
+  }
+-->

--- a/skills/accessibility/templates/header.html
+++ b/skills/accessibility/templates/header.html
@@ -1,0 +1,108 @@
+<!--
+  Accessible Header / Navigation Component
+  WCAG 2.2 AAA Compliant
+
+  Requirements met:
+  - 2.4.1  Bypass Blocks (skip link in base.html)
+  - 2.4.5  Multiple Ways (nav + search)
+  - 2.4.9  Link Purpose (link only) — descriptive link text
+  - 2.1.3  Keyboard (no exception) — full keyboard operability
+  - 2.5.5  Target Size (enhanced) — 44x44px minimum
+  - 2.4.12 Focus Not Obscured (enhanced)
+  - 2.4.13 Focus Appearance — 3px outline, 3:1 contrast
+
+  Security:
+  - Search form uses GET (safe for search queries)
+  - Output encoding required when reflecting search terms (see security-error-handling.md)
+
+  Responsive behavior:
+  - sm: Hamburger menu with off-canvas panel + overlay
+  - md: Condensed horizontal nav
+  - lg+: Full horizontal nav with all items visible
+-->
+
+<header class="site-header">
+  <div class="header-container">
+    <!-- Logo / Site Identity -->
+    <a href="/" class="site-logo" aria-label="{{SITE_NAME}} — Return to Homepage">
+      <!--
+        Use an SVG or text logo. If using an image:
+        <img src="logo.svg" alt="{{SITE_NAME}}" width="160" height="40" />
+      -->
+      <span class="logo-text">{{SITE_NAME}}</span>
+    </a>
+
+    <!-- Mobile Menu Toggle (visible on sm/md only) -->
+    <button
+      type="button"
+      class="nav-toggle"
+      aria-expanded="false"
+      aria-controls="primary-navigation"
+      aria-label="Open Navigation Menu"
+    >
+      <span class="nav-toggle-icon" aria-hidden="true"></span>
+    </button>
+
+    <!-- Overlay for mobile nav (click to close) -->
+    <div class="nav-overlay" data-open="false" aria-hidden="true"></div>
+
+    <!-- Primary Navigation -->
+    <nav
+      id="primary-navigation"
+      class="primary-nav"
+      aria-label="Primary Navigation"
+    >
+      <ul class="nav-list" role="list">
+        <li class="nav-item">
+          <a href="/about" class="nav-link" aria-current="false">About</a>
+        </li>
+        <li class="nav-item">
+          <a href="/services" class="nav-link">Services</a>
+        </li>
+        <li class="nav-item">
+          <a href="/resources" class="nav-link">Resources</a>
+        </li>
+        <li class="nav-item">
+          <a href="/contact" class="nav-link">Contact</a>
+        </li>
+      </ul>
+    </nav>
+
+    <!-- Utility Navigation (search) -->
+    <div class="utility-nav">
+      <!--
+        SECURITY: This search form uses GET, which is safe.
+        When reflecting the search term back in results, you MUST
+        encode the output to prevent reflected XSS:
+          element.textContent = searchTerm; // SAFE
+          element.innerHTML = searchTerm;   // UNSAFE
+        See references/security-error-handling.md for full guidance.
+      -->
+      <form action="/search" method="get" role="search" aria-label="Site Search">
+        <label for="site-search" class="sr-only">Search</label>
+        <input
+          type="search"
+          id="site-search"
+          name="q"
+          placeholder="Search..."
+          autocomplete="off"
+          aria-label="Search the site"
+        />
+        <button type="submit" aria-label="Submit Search">
+          <svg aria-hidden="true" focusable="false" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="11" cy="11" r="8"></circle>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+          </svg>
+          <span class="sr-only">Search</span>
+        </button>
+      </form>
+    </div>
+  </div>
+</header>
+
+<!--
+  Mobile Navigation JavaScript (include in main.js):
+
+  See templates/main.js for the complete, production-ready implementation
+  with focus trapping, Escape key handling, and overlay click-to-close.
+-->

--- a/skills/accessibility/templates/main.js
+++ b/skills/accessibility/templates/main.js
@@ -1,0 +1,297 @@
+/**
+ * Main Application JavaScript
+ * WCAG 2.2 AAA Compliant — Framework-Agnostic
+ *
+ * This file provides production-ready, accessible JavaScript for:
+ *   - Mobile navigation (toggle, focus trap, Escape key)
+ *   - Sidebar navigation (toggle, overlay, focus trap)
+ *   - Expandable sidebar sections (accordion pattern)
+ *   - Footer year auto-update
+ *   - Global error handling
+ *   - Accessible announcements (live regions)
+ *   - Confirmation dialog for destructive actions
+ *
+ * SECURITY NOTES:
+ *   - All DOM text insertion uses textContent (never innerHTML)
+ *   - All user input is treated as untrusted
+ *   - Event listeners are attached via addEventListener (no inline handlers)
+ *
+ * ARCHITECTURE:
+ *   - Each feature is encapsulated in its own function (Single Responsibility)
+ *   - No global variables are leaked (IIFE or module pattern)
+ *   - All DOM queries are performed once and cached
+ *   - Defensive null checks prevent errors when elements are absent
+ */
+
+(function () {
+  'use strict';
+
+  // ============================================
+  // UTILITY: Accessible Announcements
+  // ============================================
+
+  /**
+   * Announce a message to screen readers via a live region.
+   * @param {string} message - The message to announce (plain text only).
+   * @param {'polite'|'assertive'} priority - The urgency of the announcement.
+   */
+  function announce(message, priority) {
+    if (priority === void 0) { priority = 'polite'; }
+    var regionId = priority === 'assertive' ? 'alert-announcer' : 'status-announcer';
+    var region = document.getElementById(regionId);
+    if (region) {
+      // Clear first, then set — ensures re-announcement of identical messages
+      region.textContent = '';
+      requestAnimationFrame(function () {
+        region.textContent = message;
+      });
+    }
+  }
+
+  // ============================================
+  // UTILITY: Focus Trap
+  // ============================================
+
+  /**
+   * Creates a focus trap within a container element.
+   * @param {HTMLElement} container - The element to trap focus within.
+   * @returns {{ activate: Function, deactivate: Function }}
+   */
+  function createFocusTrap(container) {
+    var FOCUSABLE_SELECTOR = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    var handler = null;
+
+    function activate() {
+      handler = function (e) {
+        if (e.key !== 'Tab') return;
+        var focusable = container.querySelectorAll(FOCUSABLE_SELECTOR);
+        if (focusable.length === 0) return;
+        var first = focusable[0];
+        var last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      };
+      container.addEventListener('keydown', handler);
+    }
+
+    function deactivate() {
+      if (handler) {
+        container.removeEventListener('keydown', handler);
+        handler = null;
+      }
+    }
+
+    return { activate: activate, deactivate: deactivate };
+  }
+
+  // ============================================
+  // FEATURE: Mobile Navigation
+  // ============================================
+
+  function initMobileNav() {
+    var toggle = document.querySelector('.nav-toggle');
+    var nav = document.getElementById('primary-navigation');
+    var overlay = document.querySelector('.nav-overlay');
+    if (!toggle || !nav) return;
+
+    var focusTrap = createFocusTrap(nav);
+
+    function openNav() {
+      nav.setAttribute('data-open', 'true');
+      if (overlay) overlay.setAttribute('data-open', 'true');
+      toggle.setAttribute('aria-expanded', 'true');
+      toggle.setAttribute('aria-label', 'Close Navigation Menu');
+      focusTrap.activate();
+      var firstLink = nav.querySelector('.nav-link');
+      if (firstLink) firstLink.focus();
+      announce('Navigation menu opened', 'polite');
+    }
+
+    function closeNav() {
+      nav.setAttribute('data-open', 'false');
+      if (overlay) overlay.setAttribute('data-open', 'false');
+      toggle.setAttribute('aria-expanded', 'false');
+      toggle.setAttribute('aria-label', 'Open Navigation Menu');
+      focusTrap.deactivate();
+      toggle.focus();
+      announce('Navigation menu closed', 'polite');
+    }
+
+    toggle.addEventListener('click', function () {
+      var isOpen = nav.getAttribute('data-open') === 'true';
+      isOpen ? closeNav() : openNav();
+    });
+
+    if (overlay) {
+      overlay.addEventListener('click', closeNav);
+    }
+
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && nav.getAttribute('data-open') === 'true') {
+        closeNav();
+      }
+    });
+  }
+
+  // ============================================
+  // FEATURE: Sidebar Navigation
+  // ============================================
+
+  function initSidebar() {
+    var sidebar = document.getElementById('sidebar-nav');
+    var sidebarToggle = document.querySelector('.sidebar-toggle');
+    var sidebarClose = sidebar ? sidebar.querySelector('.sidebar__close') : null;
+    var sidebarOverlay = document.querySelector('.sidebar-overlay');
+    if (!sidebar || !sidebarToggle) return;
+
+    var focusTrap = createFocusTrap(sidebar);
+
+    function openSidebar() {
+      sidebar.classList.add('is-open');
+      sidebar.setAttribute('aria-hidden', 'false');
+      sidebarToggle.setAttribute('aria-expanded', 'true');
+      if (sidebarOverlay) {
+        sidebarOverlay.hidden = false;
+        sidebarOverlay.setAttribute('aria-hidden', 'false');
+      }
+      focusTrap.activate();
+      var firstLink = sidebar.querySelector('.sidebar__link');
+      if (firstLink) firstLink.focus();
+    }
+
+    function closeSidebar() {
+      sidebar.classList.remove('is-open');
+      sidebar.setAttribute('aria-hidden', 'true');
+      sidebarToggle.setAttribute('aria-expanded', 'false');
+      if (sidebarOverlay) {
+        sidebarOverlay.hidden = true;
+        sidebarOverlay.setAttribute('aria-hidden', 'true');
+      }
+      focusTrap.deactivate();
+      sidebarToggle.focus();
+    }
+
+    sidebarToggle.addEventListener('click', function () {
+      var isOpen = sidebar.classList.contains('is-open');
+      isOpen ? closeSidebar() : openSidebar();
+    });
+
+    if (sidebarClose) {
+      sidebarClose.addEventListener('click', closeSidebar);
+    }
+
+    if (sidebarOverlay) {
+      sidebarOverlay.addEventListener('click', closeSidebar);
+    }
+
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && sidebar.classList.contains('is-open')) {
+        closeSidebar();
+      }
+    });
+  }
+
+  // ============================================
+  // FEATURE: Expandable Sidebar Sections
+  // ============================================
+
+  function initExpandableSections() {
+    var expandButtons = document.querySelectorAll('.sidebar__item--expandable > .sidebar__link');
+    expandButtons.forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var expanded = btn.getAttribute('aria-expanded') === 'true';
+        var targetId = btn.getAttribute('aria-controls');
+        var target = targetId ? document.getElementById(targetId) : null;
+        if (!target) return;
+
+        btn.setAttribute('aria-expanded', String(!expanded));
+        target.hidden = expanded;
+      });
+    });
+  }
+
+  // ============================================
+  // FEATURE: Footer Year Auto-Update
+  // ============================================
+
+  function initFooterYear() {
+    var yearEl = document.getElementById('footer-year');
+    if (yearEl) {
+      // SECURITY: textContent is safe; innerHTML would be an XSS vector
+      yearEl.textContent = new Date().getFullYear().toString();
+    }
+  }
+
+  // ============================================
+  // FEATURE: Confirmation for Destructive Actions
+  // ============================================
+
+  /**
+   * Attach confirmation dialogs to all buttons marked with
+   * data-confirm="Are you sure?". Prevents the default action
+   * unless the user confirms.
+   *
+   * Usage:
+   *   <button data-confirm="Delete this item permanently?">Delete</button>
+   */
+  function initConfirmActions() {
+    document.addEventListener('click', function (e) {
+      var target = e.target.closest('[data-confirm]');
+      if (!target) return;
+      var message = target.getAttribute('data-confirm');
+      if (message && !window.confirm(message)) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+      }
+    });
+  }
+
+  // ============================================
+  // FEATURE: Global Error Handling
+  // ============================================
+
+  function initGlobalErrorHandling() {
+    window.onerror = function (message, source, lineno, colno, error) {
+      // Log to console in development; replace with remote logging in production
+      console.error('Unhandled error:', { message: message, source: source, lineno: lineno, error: error });
+      announce('An unexpected error occurred. Please try again.', 'assertive');
+      return true; // Prevents the default browser error handling
+    };
+
+    window.onunhandledrejection = function (event) {
+      console.error('Unhandled promise rejection:', event.reason);
+      announce('An unexpected error occurred. Please try again.', 'assertive');
+    };
+  }
+
+  // ============================================
+  // INITIALIZATION
+  // ============================================
+
+  /**
+   * Initialize all features when the DOM is ready.
+   * Each init function is defensive — it checks for required elements
+   * before attaching listeners, so it is safe to call on any page.
+   */
+  function init() {
+    initGlobalErrorHandling();
+    initMobileNav();
+    initSidebar();
+    initExpandableSections();
+    initFooterYear();
+    initConfirmActions();
+  }
+
+  // Run when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+})();

--- a/skills/accessibility/templates/responsive.css
+++ b/skills/accessibility/templates/responsive.css
@@ -1,0 +1,231 @@
+/*
+ * WCAG 2.2 AAA Responsive Layout System
+ * Mobile-first, 3 breakpoints minimum (sm, md, lg)
+ *
+ * Breakpoints:
+ *   sm: 0 -- 767px     (phones)
+ *   md: 768px -- 1023px (tablets)
+ *   lg: 1024px+         (desktops)
+ *   xl: 1280px+         (optional, wide desktops)
+ *
+ * WCAG compliance:
+ *   1.3.4  Orientation — no orientation lock
+ *   1.4.4  Resize Text — rem-based sizing
+ *   1.4.10 Reflow — no horizontal scroll at 320px width
+ *   2.5.5  Target Size (AAA) — 44px minimum at all breakpoints
+ */
+
+/* ========================================
+   CONTAINER
+   ======================================== */
+
+.container {
+  width: 100%;
+  margin-inline: auto;
+  padding-inline: var(--space-4);
+}
+
+/* ========================================
+   GRID SYSTEM
+   ======================================== */
+
+.grid {
+  display: grid;
+  gap: var(--space-4);
+}
+
+/* ========================================
+   sm (base): 0 -- 767px
+   Single column, stacked layout
+   ======================================== */
+
+.grid {
+  grid-template-columns: 1fr;
+}
+
+/* Header layout: stacked */
+.header-container {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  gap: var(--space-3);
+}
+
+/* Footer layout: single column */
+.footer-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-6);
+}
+
+.footer-links a {
+  display: block;
+  min-height: var(--target-size-min);
+  padding-block: var(--space-2);
+}
+
+/* ========================================
+   md: 768px -- 1023px
+   Two-column layouts, expanded navigation
+   ======================================== */
+
+@media (min-width: 768px) {
+  .container {
+    max-width: var(--container-md);
+    padding-inline: var(--space-5);
+  }
+
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--space-5);
+  }
+
+  .grid--3 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  /* Header: horizontal layout */
+  .header-container {
+    flex-wrap: nowrap;
+    padding: var(--space-4) var(--space-5);
+  }
+
+  /* Footer: 2-column */
+  .footer-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--space-6);
+  }
+}
+
+/* ========================================
+   lg: 1024px+
+   Full multi-column layouts
+   ======================================== */
+
+@media (min-width: 1024px) {
+  .container {
+    max-width: var(--container-lg);
+    padding-inline: var(--space-6);
+  }
+
+  .grid {
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-6);
+  }
+
+  .grid--2 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .grid--3 {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .grid--4 {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  /* Header: full horizontal nav */
+  .nav-toggle {
+    display: none;
+  }
+
+  .primary-nav {
+    display: flex;
+  }
+
+  .nav-list {
+    display: flex;
+    gap: var(--space-4);
+    list-style: none;
+  }
+
+  /* Footer: multi-column */
+  .footer-grid {
+    grid-template-columns: 2fr repeat(3, 1fr);
+    gap: var(--space-6);
+  }
+}
+
+/* ========================================
+   xl: 1280px+ (optional enhancement)
+   ======================================== */
+
+@media (min-width: 1280px) {
+  .container {
+    max-width: var(--container-xl);
+  }
+}
+
+/* ========================================
+   TEXT CONTAINER (WCAG 1.4.8)
+   Max 80 characters per line
+   ======================================== */
+
+.text-container {
+  max-width: var(--max-line-width);
+}
+
+/* ========================================
+   REFLOW SUPPORT (WCAG 1.4.10)
+   Ensure no horizontal scroll at 320px
+   ======================================== */
+
+img, video, iframe, object, embed, svg {
+  max-width: 100%;
+  height: auto;
+}
+
+/*
+ * FIX: Do NOT use `display: block` on <table> — it breaks table
+ * semantics for screen readers. Use a wrapper <div> instead.
+ */
+.table-responsive {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+pre, code {
+  overflow-x: auto;
+  max-width: 100%;
+}
+
+/* ========================================
+   FLUID SPACING (Modern Best Practice)
+   Sections use clamp() for smooth scaling
+   ======================================== */
+
+.section {
+  padding-block: clamp(2rem, 1rem + 5vw, 6rem);
+}
+
+/* ========================================
+   PRINT STYLES
+   ======================================== */
+
+@media print {
+  .nav-toggle,
+  .skip-link,
+  .utility-nav {
+    display: none;
+  }
+
+  body {
+    font-size: 12pt;
+    line-height: 1.5;
+    color: #000;
+    background: #fff;
+  }
+
+  a {
+    color: #000;
+    text-decoration: underline;
+  }
+
+  a[href]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.875em;
+  }
+}

--- a/skills/accessibility/templates/sidebar-nav.html
+++ b/skills/accessibility/templates/sidebar-nav.html
@@ -1,0 +1,114 @@
+<!--
+  Sidebar Navigation Template
+  WCAG 2.2 AAA Compliant
+
+  Features:
+  - Collapsible sidebar with toggle button
+  - Hierarchical navigation with expandable sections
+  - aria-current="page" for active item
+  - aria-expanded for collapsible sections
+  - Keyboard navigable
+  - Responsive: collapses to overlay on mobile
+
+  Replace placeholder content with actual navigation items.
+  All classes reference `tokens.css` and `components.css` for styling.
+-->
+
+<!-- Sidebar Toggle (visible when sidebar is collapsed or on mobile) -->
+<button
+  type="button"
+  class="sidebar-toggle"
+  aria-label="Open navigation menu"
+  aria-expanded="false"
+  aria-controls="sidebar-nav"
+>
+  <!-- Hamburger icon using inline SVG for accessibility -->
+  <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <line x1="3" y1="6" x2="21" y2="6" />
+    <line x1="3" y1="12" x2="21" y2="12" />
+    <line x1="3" y1="18" x2="21" y2="18" />
+  </svg>
+</button>
+
+<!-- Sidebar Navigation -->
+<aside id="sidebar-nav" class="sidebar" aria-label="Main navigation">
+  <!-- Sidebar Header -->
+  <div class="sidebar__header">
+    <span class="sidebar__brand">Application Name</span>
+    <button
+      type="button"
+      class="sidebar__close"
+      aria-label="Close navigation menu"
+    >
+      <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <line x1="18" y1="6" x2="6" y2="18" />
+        <line x1="6" y1="6" x2="18" y2="18" />
+      </svg>
+    </button>
+  </div>
+
+  <!-- Navigation List -->
+  <nav aria-label="Primary">
+    <ul class="sidebar__nav" role="list">
+      <!-- Active item -->
+      <li class="sidebar__item sidebar__item--active">
+        <a href="/dashboard" class="sidebar__link" aria-current="page">
+          <svg class="sidebar__icon" aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <rect x="3" y="3" width="7" height="7" />
+            <rect x="14" y="3" width="7" height="7" />
+            <rect x="3" y="14" width="7" height="7" />
+            <rect x="14" y="14" width="7" height="7" />
+          </svg>
+          <span class="sidebar__label">Dashboard</span>
+        </a>
+      </li>
+
+      <!-- Expandable section -->
+      <li class="sidebar__item sidebar__item--expandable">
+        <button
+          type="button"
+          class="sidebar__link"
+          aria-expanded="false"
+          aria-controls="nav-reports"
+        >
+          <svg class="sidebar__icon" aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+            <polyline points="14 2 14 8 20 8" />
+          </svg>
+          <span class="sidebar__label">Reports</span>
+          <svg class="sidebar__chevron" aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </button>
+        <ul id="nav-reports" class="sidebar__subnav" role="list" hidden>
+          <li><a href="/reports/quarterly" class="sidebar__sublink">Quarterly</a></li>
+          <li><a href="/reports/annual" class="sidebar__sublink">Annual</a></li>
+          <li><a href="/reports/custom" class="sidebar__sublink">Custom</a></li>
+        </ul>
+      </li>
+
+      <!-- Standard items -->
+      <li class="sidebar__item">
+        <a href="/projects" class="sidebar__link">
+          <svg class="sidebar__icon" aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+          </svg>
+          <span class="sidebar__label">Projects</span>
+        </a>
+      </li>
+
+      <li class="sidebar__item">
+        <a href="/settings" class="sidebar__link">
+          <svg class="sidebar__icon" aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <circle cx="12" cy="12" r="3" />
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+          </svg>
+          <span class="sidebar__label">Settings</span>
+        </a>
+      </li>
+    </ul>
+  </nav>
+</aside>
+
+<!-- Overlay for mobile (behind sidebar) -->
+<div class="sidebar-overlay" aria-hidden="true" hidden></div>

--- a/skills/accessibility/templates/tokens.css
+++ b/skills/accessibility/templates/tokens.css
@@ -1,0 +1,515 @@
+/*
+ * WCAG 2.2 AAA Design Tokens & Base Styles
+ * Framework-agnostic CSS custom properties
+ *
+ * All color pairings meet AAA contrast requirements:
+ * - Normal text: >= 7:1
+ * - Large text (>=18pt or >=14pt bold): >= 4.5:1
+ * - UI components: >= 3:1
+ *
+ * Replace values with brand colors after verifying contrast
+ * using: python3 scripts/check_contrast.py <fg> <bg>
+ */
+
+:root {
+  /* ========================================
+     COLOR TOKENS
+     ======================================== */
+
+  /* Primary */
+  --color-primary: #1a365d;
+  --color-primary-dark: #0f2440;
+  --color-primary-light: #2a4a7f;
+
+  /* Secondary */
+  --color-secondary: #2d5016;
+  --color-secondary-dark: #1e3a0f;
+
+  /* Text */
+  --color-text: #1a1a1a;
+  --color-text-muted: #3d3d3d;
+  --color-text-inverse: #ffffff;
+
+  /* Backgrounds */
+  --color-bg: #ffffff;
+  --color-bg-alt: #f5f5f5;
+  --color-bg-dark: #1a1a1a;
+
+  /* Borders */
+  --color-border: #4a4a4a;
+  --color-border-light: #6b6b6b;
+
+  /* Semantic */
+  --color-error: #8b0000;
+  --color-error-bg: #fef2f2;
+  --color-success: #1a5c1a;
+  --color-success-bg: #f0fdf4;
+  --color-warning: #6b4c00;
+  --color-warning-bg: #fffbeb;
+  --color-info: #0050a0;
+  --color-info-bg: #eff6ff;
+
+  /* Skeleton / Loading */
+  --color-skeleton: #e0e0e0;
+  --color-skeleton-highlight: #f0f0f0;
+
+  /* Focus */
+  --color-focus: #0050a0;
+  --focus-outline-width: 3px;
+  --focus-outline-offset: 2px;
+
+  /* ========================================
+     TYPOGRAPHY TOKENS
+     ======================================== */
+
+  /* Font Families */
+  --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  --font-heading: var(--font-body);
+  --font-mono: "SF Mono", "Fira Code", "Fira Mono", "Roboto Mono",
+    "Courier New", monospace;
+
+  /* Font Sizes (rem-based, 1rem = 16px) */
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+
+  /* Font Weights */
+  --font-normal: 400;
+  --font-medium: 500;
+  --font-semibold: 600;
+  --font-bold: 700;
+
+  /* Line Heights (WCAG 1.4.8: minimum 1.5 for ALL text) */
+  --leading-normal: 1.625;
+  --leading-relaxed: 1.75;
+  --leading-heading: 1.5; /* AAA minimum for headings */
+
+  /* Max Line Width (WCAG 1.4.8: max 80 characters) */
+  --max-line-width: 80ch;
+
+  /* ========================================
+     SPACING TOKENS
+     ======================================== */
+
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --space-8: 3rem;
+  --space-10: 4rem;
+  --space-12: 6rem;
+
+  /* ========================================
+     LAYOUT TOKENS
+     ======================================== */
+
+  /* Breakpoints (for reference; use in @media queries) */
+  --bp-sm: 0px;
+  --bp-md: 768px;
+  --bp-lg: 1024px;
+  --bp-xl: 1280px;
+  --bp-xxl: 1536px;
+
+  /* Container widths */
+  --container-sm: 100%;
+  --container-md: 720px;
+  --container-lg: 960px;
+  --container-xl: 1140px;
+
+  /* ========================================
+     COMPONENT TOKENS
+     ======================================== */
+
+  /* Border Radius */
+  --radius-sm: 0.125rem;
+  --radius-md: 0.25rem;
+  --radius-lg: 0.5rem;
+
+  /* Minimum Interactive Target Size (WCAG 2.5.5 AAA: 44px) */
+  --target-size-min: 44px;
+
+  /* Transition (respects prefers-reduced-motion) */
+  --transition-fast: 0.15s ease-in-out;
+  --transition-normal: 0.3s ease-in-out;
+
+  /* Z-Index Scale */
+  --z-dropdown: 100;
+  --z-sticky: 200;
+  --z-overlay: 300;
+  --z-modal: 400;
+  --z-toast: 500;
+}
+
+/* ========================================
+   BASE RESET & ACCESSIBILITY FOUNDATIONS
+   ======================================== */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 100%; /* 16px base — never override with px */
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+/* scroll-behavior: smooth only when user has no motion preference */
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
+}
+
+body {
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  font-weight: var(--font-normal);
+  line-height: var(--leading-normal);
+  color: var(--color-text);
+  background-color: var(--color-bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Text alignment: never justify (WCAG 1.4.8) */
+p, li, dd, td, th {
+  text-align: start; /* logical property — supports RTL */
+}
+
+/* Max line width (WCAG 1.4.8) */
+p, li, dd, blockquote {
+  max-width: var(--max-line-width);
+}
+
+/* Headings — line-height 1.5 minimum for AAA (1.4.8) */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading);
+  font-weight: var(--font-bold);
+  line-height: var(--leading-heading);
+  color: var(--color-text);
+}
+
+h1 { font-size: var(--text-4xl); margin-block-end: var(--space-6); }
+h2 { font-size: var(--text-3xl); margin-block-end: var(--space-5); }
+h3 { font-size: var(--text-2xl); margin-block-end: var(--space-4); }
+h4 { font-size: var(--text-xl); margin-block-end: var(--space-4); }
+
+/* Paragraph spacing: >= 2x line-height (WCAG 1.4.8) */
+p + p {
+  margin-block-start: var(--space-5);
+}
+
+/* ========================================
+   FOCUS STYLES (WCAG 2.4.13 AAA)
+   ======================================== */
+
+/*
+ * FIX: Do NOT use `:focus { outline: none; }` globally.
+ * That removes focus for browsers that do not support :focus-visible.
+ * Instead, use :focus:not(:focus-visible) for graceful degradation.
+ */
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
+:focus-visible {
+  outline: var(--focus-outline-width) solid var(--color-focus);
+  outline-offset: var(--focus-outline-offset);
+  border-radius: var(--radius-sm);
+}
+
+/* ========================================
+   SKIP LINK (WCAG 2.4.1)
+   ======================================== */
+
+.skip-link {
+  position: absolute;
+  top: -100%;
+  inset-inline-start: var(--space-4);
+  z-index: 9999;
+  padding: var(--space-3) var(--space-5);
+  background-color: var(--color-bg);
+  color: var(--color-primary);
+  font-weight: var(--font-semibold);
+  text-decoration: underline;
+  border: 2px solid var(--color-primary);
+  border-radius: var(--radius-md);
+}
+
+.skip-link:focus {
+  top: var(--space-4);
+}
+
+/* ========================================
+   SCREEN READER ONLY UTILITY
+   ======================================== */
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ========================================
+   LINKS (WCAG 1.4.1 — not color-only)
+   ======================================== */
+
+a {
+  color: var(--color-primary);
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+  text-decoration-thickness: 1px;
+}
+
+a:hover {
+  color: var(--color-primary-dark);
+  text-decoration-thickness: 2px;
+}
+
+a:focus-visible {
+  outline: var(--focus-outline-width) solid var(--color-focus);
+  outline-offset: var(--focus-outline-offset);
+  border-radius: var(--radius-sm);
+}
+
+/* ========================================
+   INTERACTIVE ELEMENTS — TARGET SIZE (2.5.5)
+   ======================================== */
+
+button,
+[role="button"],
+input[type="submit"],
+input[type="reset"],
+input[type="button"],
+select,
+summary {
+  min-height: var(--target-size-min);
+  min-width: var(--target-size-min);
+  cursor: pointer;
+}
+
+input[type="text"],
+input[type="email"],
+input[type="password"],
+input[type="search"],
+input[type="tel"],
+input[type="url"],
+input[type="number"],
+input[type="date"],
+textarea,
+select {
+  min-height: var(--target-size-min);
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background-color: var(--color-bg);
+  color: var(--color-text);
+}
+
+/* ========================================
+   FORM ERROR STATES (1.4.1, 3.3.1)
+   Error indication must NOT rely on color alone.
+   ======================================== */
+
+.form-error-field {
+  border-color: var(--color-error);
+  box-shadow: inset 3px 0 0 var(--color-error); /* visual indicator beyond color */
+}
+
+.form-error-message {
+  color: var(--color-error);
+  font-size: var(--text-sm);
+  margin-block-start: var(--space-1);
+}
+
+/* Prefix error messages with a text indicator */
+.form-error-message::before {
+  content: "Error: ";
+  font-weight: var(--font-bold);
+}
+
+/* ========================================
+   ACCESSIBLE DATA TABLES
+   ======================================== */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+th, td {
+  padding: var(--space-3) var(--space-4);
+  border-block-end: 1px solid var(--color-border-light);
+  text-align: start;
+  vertical-align: top;
+}
+
+th {
+  font-weight: var(--font-semibold);
+  background-color: var(--color-bg-alt);
+}
+
+caption {
+  font-weight: var(--font-bold);
+  text-align: start;
+  margin-block-end: var(--space-3);
+}
+
+/* Responsive table wrapper — preserves table semantics for screen readers */
+.table-responsive {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* ========================================
+   BREADCRUMB (2.4.8 AAA)
+   ======================================== */
+
+.breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  list-style: none;
+  padding: 0;
+  gap: var(--space-2);
+}
+
+.breadcrumb li + li::before {
+  content: "/";
+  padding-inline-end: var(--space-2);
+  color: var(--color-text-muted);
+}
+
+.breadcrumb a {
+  min-height: var(--target-size-min);
+  display: inline-flex;
+  align-items: center;
+}
+
+.breadcrumb [aria-current="page"] {
+  color: var(--color-text);
+  text-decoration: none;
+  font-weight: var(--font-semibold);
+}
+
+/* ========================================
+   ALERT / NOTIFICATION (4.1.3)
+   ======================================== */
+
+.alert {
+  padding: var(--space-4);
+  border: 2px solid;
+  border-radius: var(--radius-md);
+  margin-block-end: var(--space-4);
+}
+
+.alert--error {
+  background-color: var(--color-error-bg);
+  border-color: var(--color-error);
+  color: var(--color-error);
+}
+
+.alert--success {
+  background-color: var(--color-success-bg);
+  border-color: var(--color-success);
+  color: var(--color-success);
+}
+
+.alert--warning {
+  background-color: var(--color-warning-bg);
+  border-color: var(--color-warning);
+  color: var(--color-warning);
+}
+
+.alert--info {
+  background-color: var(--color-info-bg);
+  border-color: var(--color-info);
+  color: var(--color-info);
+}
+
+/* ========================================
+   EXTERNAL LINKS (Security Best Practice)
+   ======================================== */
+
+a[target="_blank"]::after {
+  content: " \2197"; /* north-east arrow */
+  font-size: 0.75em;
+  vertical-align: super;
+}
+
+/* ========================================
+   DISABLED STATE
+   ======================================== */
+
+[aria-disabled="true"] {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* ========================================
+   REDUCED MOTION (WCAG 2.3.3 AAA)
+   ======================================== */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ========================================
+   HIGH CONTRAST MODE (prefers-contrast)
+   ======================================== */
+
+@media (prefers-contrast: more) {
+  :root {
+    --color-border: #000000;
+    --color-border-light: #333333;
+    --focus-outline-width: 4px;
+  }
+
+  a {
+    text-decoration-thickness: 2px;
+  }
+}
+
+/* ========================================
+   FORCED COLORS MODE (Windows High Contrast)
+   ======================================== */
+
+@media (forced-colors: active) {
+  .skip-link,
+  .alert {
+    border: 2px solid;
+  }
+
+  :focus-visible {
+    outline: 3px solid;
+  }
+}

--- a/skills/depression-sensitive-content/SKILL.md
+++ b/skills/depression-sensitive-content/SKILL.md
@@ -146,6 +146,7 @@ When uncertain:
 - **[references/examples.md](references/examples.md)** - Good/bad examples
 - **[references/alternatives.md](references/alternatives.md)** - Alternative phrases
 - **[references/quick-reference.md](references/quick-reference.md)** - Quick reference guide
+- **[references/implementation-guide.md](references/implementation-guide.md)** - Deep implementation guide: 7 rewrite principles with clinical rationale, 15 worked examples, full standards traceability matrix (WCAG 2.2 / COGA / ISO 9241-110 / ISO/IEC 30071-1), 40+ item audit checklist, localization guidance
 
 ## Progressive Disclosure
 

--- a/skills/depression-sensitive-content/references/implementation-guide.md
+++ b/skills/depression-sensitive-content/references/implementation-guide.md
@@ -1,0 +1,1743 @@
+# Depression-Sensitive Web Content Support - Implementation Guide
+
+This document provides comprehensive guidance for auditing and rewriting web content to reduce emotional distress and cognitive load. This is a UX and content accessibility tool, NOT a clinical resource. For mental health concerns, consult qualified healthcare professionals.
+
+---
+
+## Section A: Rewrite Library
+
+### A.1 Core Principles
+
+This section defines seven foundational principles for depression-sensitive content design. Each principle includes clinical rationale, standards mapping, and practical implementation guidance.
+
+#### Principle 1: Remove Shame and Blame Language
+
+**Definition:** Error messages and system feedback shall attribute failures to system conditions or input format issues rather than to user character, ability, or character.
+
+**Clinical Rationale:** Shame-inducing language activates the brain's threat response systems, including the amygdala. Research in cognitive psychology demonstrates that threat activation impairs executive function, including problem-solving capabilities and working memory. For users experiencing depressive symptoms, this impairment is compounded by existing deficits in cognitive flexibility and processing speed. Depersonalized language preserves the user's sense of agency and competence.
+
+**Standards Mapping:**
+- WCAG 2.2 Success Criterion 3.3.1 (Level A): Error Identification - "If an input error is automatically detected and the user is identified, then the error is described to the user in text."
+- WCAG 2.2 Success Criterion 3.3.2 (Level A): Labels or Instructions - "Labels or instructions are provided when content requires user input."
+- W3C COGA Objective 2: Help users avoid making mistakes - "Make it easy to understand what is wrong and how to correct mistakes."
+- ISO 9241-110:2006 Clause 5.4 (Conformity with user expectations): "The dialogue conforms with user expectations by being consistent and conforming to generally accepted conventions."
+- ISO 9241-110:2006 Clause 5.7 (Error tolerance): "The dialogue is error-tolerant if, despite evident errors in input, the intended result may be achieved with no or minimal recovery effort."
+
+**Implementation Guidance:**
+- Replace "You" statements with system-focused language: "Your session expired" → "Session expired due to inactivity"
+- Use passive voice for system failures: "You entered invalid data" → "Email format not recognized"
+- Avoid exclamation points in error states: "Invalid!" → "Not recognized"
+- Never attribute failure to user intelligence or character: "You're too stupid to use this" → N/A (obvious)
+- Provide neutral diagnostic information: "Your password is wrong" → "Password not found for this email"
+
+---
+
+#### Principle 2: Reduce Urgency Pressure
+
+**Definition:** Interface communications shall avoid time-dependent pressure tactics, countdown timers, and urgent language that may induce anxiety or precipitate hasty decision-making.
+
+**Clinical Rationale:** Depressive disorders frequently involve impaired executive function, including reduced processing speed and decision-making capacity. Time pressure creates artificial cognitive load that compounds these deficits. Additionally, anxiety and depression often co-occur, with time pressure serving as an anxiety trigger that may exacerbate depressive symptoms. Extended time allowances and neutral framing support cognitive processing without inducing stress responses.
+
+**Standards Mapping:**
+- WCAG 2.2 Success Criterion 2.2.6 (Level AAA): Timeouts - "Users are warned of the duration of any user inactivity that could cause data loss, unless the data is preserved for more than 20 hours."
+- WCAG 2.2 Success Criterion 3.2.5 (Level AA): Change on Request - "Changes to the value of any user interface component does not automatically cause a change of context unless the user has been advised of the behavior before using the component."
+- W3C COGA Objective 4: Provide help and support - "Make it easy to get help and have extra time if needed."
+- ISO 9241-110:2006 Clause 5.5 (Controllability): "The dialogue is controllable when the user is able to initiate and control the direction and pace of interaction to the extent needed."
+
+**Implementation Guidance:**
+- Eliminate countdown timers on forms requiring cognitive input (applications, checkout, account creation)
+- Replace "ACT NOW!", "Limited time!", "Last chance!" with neutral time indicators: "Offer expires in 7 days"
+- Extend default timeouts to maximum practical duration; warn well in advance of expiration
+- Avoid auto-submit on time limits; require explicit user action
+- Remove false urgency: "Only 2 items left!" → "Limited availability" or remove entirely
+
+---
+
+#### Principle 3: Self-Descriptive Call-to-Action Labels
+
+**Definition:** Interactive elements shall use labels that describe the specific outcome or result of the interaction rather than generic commands or action verbs.
+
+**Clinical Rationale:** Depression impairs working memory capacity, reducing the ability to hold intermediate steps in conscious attention. Self-descriptive labels reduce cognitive load by eliminating the need for users to recall or infer what happens when clicking a button. Clear outcome descriptions also support prospective memory (remembering to perform future intentions) which is particularly affected in depressive states.
+
+**Standards Mapping:**
+- WCAG 2.2 Success Criterion 2.4.6 (Level AA): Headings and Labels - "Headings and labels describe topic or purpose."
+- WCAG 2.2 Success Criterion 2.4.9 (Level AAA): Link Purpose (Link Only) - "A mechanism is available to allow the purpose of each link to be identified from link text alone."
+- W3C COGA Objective 1: Help users understand what things are and how to use them - "Use clear and simple language and provide consistent navigation."
+- ISO 9241-110:2006 Clause 5.2 (Self-descriptiveness): "The dialogue is self-descriptive when each dialogue step is immediately comprehensible through feedback from the system or is annotated by the user."
+
+**Implementation Guidance:**
+- Replace generic "Submit" with outcome description: "Create account", "Send message", "Save draft"
+- Replace "Click here" with descriptive links: "View pricing plans", "Read the guide"
+- Replace "Go" or "Start" with specific outcomes: "Start free trial", "Begin application"
+- Button labels should answer: "What happens when I click this?"
+- Consider adding parenthetical context: "Continue (to payment)" vs. "Continue (to next step)"
+
+---
+
+#### Principle 4: Error Recovery Templates
+
+**Definition:** Every error condition shall include explicit, actionable guidance on how to resolve the error and proceed with the user's intended task.
+
+**Clinical Rationale:** Learned helplessness is a well-documented phenomenon in depression research, characterized by the belief that one's actions have no effect on outcomes. Error messages without recovery paths may reinforce this belief, leading to task abandonment. Conversely, clear recovery paths restore the user's sense of agency and competence. Error recovery guidance also reduces working memory load by eliminating the need to generate solutions independently.
+
+**Standards Mapping:**
+- WCAG 2.2 Success Criterion 3.3.3 (Level AA): Error Suggestion - "If an input error is automatically detected and suggestions for correction are known, then the suggestions are provided to the user, unless it would jeopardize the security or purpose of the content."
+- WCAG 2.2 Success Criterion 3.3.4 (Level AA): Error Prevention (Legal, Financial, Data) - "For pages that cause legal commitments or financial transactions for the user to occur, that result in the user's data being deleted or modified, the user can reverse, correct, or confirm the action."
+- W3C COGA Objective 2: Help users avoid making mistakes - "Make it easy to understand what is wrong and how to correct mistakes. Make it easy to undo mistakes."
+- ISO 9241-110:2006 Clause 5.7 (Error tolerance): "The dialogue is error-tolerant if, despite evident errors in input, the intended result may be achieved with no or minimal recovery effort."
+
+**Implementation Guidance:**
+- Every error message must answer: "What do I do now?"
+- Provide concrete examples for format errors: "Email format not recognized. Example: name@domain.com"
+- Include specific remediation steps: "Check your email for the confirmation link"
+- Offer alternative paths: "If problems persist, contact support@example.com"
+- Avoid blank "Error" messages or technical jargon without context
+
+---
+
+#### Principle 5: Reduce Memory Reliance
+
+**Definition:** Interfaces shall display necessary information rather than requiring users to recall information from previous interactions, external documents, or memory.
+
+**Clinical Rationale:** Depression is associated with significant impairments in working memory, the cognitive system responsible for temporarily holding and manipulating information. These deficits affect the ability to hold information "in mind" across multiple steps, recall credentials or identifiers from memory, and maintain task goals during interruptions. Interfaces that minimize memory demands support successful task completion for users with cognitive impairments.
+
+**Standards Mapping:**
+- WCAG 2.2 Success Criterion 3.3.7 (Level A): Redundant Entry - "Information previously entered by or provided to the user is either auto-populated or available for selection, except when re-entering information is essential, the information is required by the security settings, or the previously entered information is no longer valid."
+- WCAG 2.2 Success Criterion 3.2.6 (Level AA): Consistent Help - "If a web page contains any interactive help and there is more than one web page with consistent help, the help is accessible in a consistent way."
+- W3C COGA Objective 3: Help users find what they need - "Make it easy to find what they need, including making it easy to navigate and providing cues to help users find what they need."
+- ISO 9241-110:2006 Clause 5.3 (Suitability for the task): "The dialogue is suitable for the task when it facilitates the effective and efficient completion of the task by the user."
+
+**Implementation Guidance:**
+- Auto-populate known information from user profiles
+- Provide "Remember me" options for authentication
+- Display help text inline rather than requiring recall from documentation
+- Show password requirements before entry rather than after failure
+- Provide clear field references: "Policy number (found on your insurance card, top right)"
+- Avoid forcing users to navigate away and return to retrieve information
+
+---
+
+#### Principle 6: Scannable Plain Language
+
+**Definition:** Content shall be composed of short, clearly organized sections with key information presented first, using vocabulary accessible to users with varying literacy levels.
+
+**Clinical Rationale:** Depression frequently involves difficulties with concentration and attention, making it challenging to process lengthy or complex text. Cognitive load theory demonstrates that working memory capacity is limited; when cognitive demands exceed capacity, comprehension fails. Plain language with clear structure reduces processing demands, supporting comprehension for users with attentional deficits. Frontloading key information (inverted pyramid style) allows users to grasp essential content without completing entire passages.
+
+**Standards Mapping:**
+- WCAG 2.2 Success Criterion 3.1.5 (Level AAA): Reading Level - "When text requires reading ability more advanced than the lower secondary education level, supplemental content is available at a lower reading level."
+- WCAG 2.2 Success Criterion 3.1.4 (Level AAA): Unusual Words - "A mechanism is available for identifying specific definitions of words or phrases used in an unusual or restricted way, including idioms and jargon."
+- W3C COGA Objective 1: Help users understand what things are and how to use them - "Use clear and simple language."
+- W3C COGA Objective 3: Help users find what they need - "Break information into smaller manageable chunks with clear titles."
+- ISO 9241-110:2006 Clause 5.3 (Suitability for the task): "Information presentation shall be appropriate to the task and shall not include irrelevant or unnecessary information."
+
+**Implementation Guidance:**
+- Use bullet points and numbered lists for multi-step processes
+- Frontload key information: "Account created successfully" before additional details
+- Limit paragraphs to 2-3 sentences maximum
+- Use headings to organize content into scannable sections
+- Define technical terms on first use or in a glossary
+- Aim for 8th-grade reading level or lower for instructional content
+
+---
+
+#### Principle 7: Calm UI Microcopy Patterns
+
+**Definition:** Interface text shall use a neutral-to-supportive tone, avoiding excessive enthusiasm, alarm, or emotional manipulation.
+
+**Clinical Rationale:** Depression affects emotional regulation, making users more susceptible to emotional reactions to interface text. Exaggerated positive language (excessive exclamation points, "Congratulations!", "Amazing!") may feel incongruent or dismissive when users are struggling. Conversely, alarming language (errors marked "CRITICAL", "DANGER", "URGENT") may trigger anxiety responses. Neutral, informative language maintains a professional tone that respects users' emotional states without adding additional affective load.
+
+**Standards Mapping:**
+- ISO 9241-110:2006 Clause 5.4 (Conformity with user expectations): "The dialogue conforms with user expectations by being consistent and conforming to generally accepted conventions."
+- ISO/IEC 30071-1:2019 Clause 8.2: Accessibility policy shall address inclusive language and non-discriminatory content in all user-facing communications.
+- W3C COGA Objective 1: Help users understand what things are - "Use a neutral tone and avoid language that may be upsetting."
+- W3C COGA Objective 4: Provide help and support - "Provide a calm, supportive interface without pressure tactics."
+
+**Implementation Guidance:**
+- Use periods instead of exclamation points in most contexts
+- Replace "Congratulations!" with informative confirmation: "Account created successfully"
+- Use "Warning" sparingly; prefer descriptive labels: "Warning: Unsaved changes" vs. "DANGER!"
+- Avoid conditional threats: "If you don't subscribe now, you'll miss..."
+- Use supportive language: "We couldn't find your account" vs. "Your account doesn't exist"
+- Maintain consistent tone across all interface states
+
+---
+
+### A.2 Before/After Rewrite Examples
+
+The following examples demonstrate the application of depression-sensitive content principles across various interface contexts. Each example includes the original content, the recommended rewrite, rationale for changes, and standards mapping.
+
+**Example 1: 404 Error Page (General Web)**
+
+*Original:*
+```
+Oops! You broke something. This page doesn't exist.
+```
+
+*Recommended Rewrite:*
+```
+Page not found.
+
+The page you're looking for doesn't exist or has been moved. Check the URL for typos, or return to the homepage to find what you need.
+```
+
+*Rationale:*
+- Removed second-person blame ("You broke")
+- Changed from first-person apology to neutral statement
+- Provided specific recovery actions (check URL, return home)
+- No exclamation points
+- Clear, informative tone
+
+*Standards Mapping:*
+- WCAG 3.3.1 (Error Identification): Error is clearly described
+- WCAG 3.3.3 (Error Suggestion): Recovery path provided
+- ISO 9241-110 (Error tolerance): User can recover with minimal effort
+- COGA Objective 2: Easy to understand and correct mistakes
+
+---
+
+**Example 2: Form Validation - Email Field (E-commerce)**
+
+*Original:*
+```
+Invalid email! Try again.
+```
+
+*Recommended Rewrite:*
+```
+Email format not recognized.
+
+Please enter an email address in this format: name@domain.com
+```
+
+*Rationale:*
+- Depersonalized: attributes to format, not user
+- Removed exclamation point (calm tone)
+- Provided concrete example (reduces memory load)
+- Includes specific format guidance (recovery)
+
+*Standards Mapping:*
+- WCAG 3.3.1 (Error Identification): Error identified as format issue
+- WCAG 3.3.3 (Error Suggestion): Format example provided
+- ISO 9241-110 (Self-descriptiveness): Clear error explanation
+- COGA Objective 2: Easy to understand and correct
+
+---
+
+**Example 3: Account Signup Call-to-Action (General Web)**
+
+*Original:*
+```
+Sign up now!
+```
+
+*Recommended Rewrite:*
+```
+Create your account
+
+(Takes about 2 minutes)
+```
+
+*Rationale:*
+- Self-descriptive outcome rather than command
+- Added time expectation (reduces uncertainty)
+- Neutral, informative tone
+- No urgency pressure
+
+*Standards Mapping:*
+- WCAG 2.4.6 (Headings and Labels): Label describes purpose
+- ISO 9241-110 (Self-descriptiveness): Clear what action does
+- COGA Objective 1: Clear and simple language
+- ISO 9241-110 (Controllability): User knows what to expect
+
+---
+
+**Example 4: Empty State - Mood Tracking Dashboard (Sensitive Context)**
+
+*Original:*
+```
+No activities logged.
+
+You should track your mood daily to see your progress over time.
+```
+
+*Recommended Rewrite:*
+```
+When you log activities, they'll appear here.
+
+Optional: Track your mood daily to identify patterns in your energy and wellbeing.
+```
+
+*Rationale:*
+- Removed "should" (obligation language)
+- Added temporal framing ("When you log" vs. "No activities")
+- Emphasized optionality
+- Changed "progress" to neutral "patterns"
+- Supportive rather than admonishing tone
+
+*Standards Mapping:*
+- COGA Objective 1: Clear, simple, non-obligatory language
+- COGA Objective 4: Provide help without pressure
+- ISO 9241-110 (Controllability): User controls pace and choice
+- ISO/IEC 30071-1: Supports emotional safety in content
+
+---
+
+**Example 5: System Error Message (General Web)**
+
+*Original:*
+```
+Fatal error! Contact administrator immediately!
+```
+
+*Recommended Rewrite:*
+```
+System error (Error code: 500)
+
+We've been notified and will investigate. Please try again in 5 minutes. If the problem continues, contact support@example.com or call 555-0123.
+```
+
+*Rationale:*
+- Removed alarming "Fatal" classification
+- Added error code for reference (supports debugging)
+- Provided timeframe for retry (reduces uncertainty)
+- Included multiple contact options
+- Neutral, professional tone
+
+*Standards Mapping:*
+- WCAG 3.3.1 (Error Identification): Error clearly identified
+- WCAG 3.3.3 (Error Suggestion): Recovery steps provided
+- ISO 9241-110 (Error tolerance): User can recover
+- COGA Objective 2: Easy to understand and correct
+
+---
+
+**Example 6: Password Reset - Health Portal (Sensitive Context)**
+
+*Original:*
+```
+Forgot password? Reset it here.
+```
+
+*Recommended Rewrite:*
+```
+Reset password
+
+We'll email you a secure link to create a new password.
+```
+
+*Rationale:*
+- Self-descriptive: describes what happens
+- Reduced anxiety by explaining process
+- "Secure link" builds trust (important for health context)
+- No question-mark uncertainty
+- Clear expectation setting
+
+*Standards Mapping:*
+- WCAG 3.3.8 (Accessible Authentication): Clear authentication process
+- WCAG 3.3.3 (Error Suggestion): Process explained
+- COGA Objective 3: Reduces memory reliance
+- ISO 9241-110 (Self-descriptiveness): Clear what happens
+
+---
+
+**Example 7: Onboarding Step - Wellness Platform (Sensitive Context)**
+
+*Original:*
+```
+Complete your profile now to unlock all features!
+```
+
+*Recommended Rewrite:*
+```
+Step 2 of 4: Add profile details
+
+This step is optional. You can skip and return later, or complete it now to personalize your experience.
+```
+
+*Rationale:*
+- Shows progress (reduces uncertainty)
+- Emphasized optionality ("This step is optional")
+- Offered skip option (controllability)
+- No urgency or obligation language
+- "Personalize" is positive without pressure
+
+*Standards Mapping:*
+- WCAG 3.2.6 (Consistent Help): Help is accessible and consistent
+- COGA Objective 4: Provide help without pressure
+- ISO 9241-110 (Controllability): User controls pace
+- ISO 9241-110 (Conformity with expectations): Clear what to expect
+
+---
+
+**Example 8: Loading State (General Web)**
+
+*Original:*
+```
+Please wait...
+```
+
+*Recommended Rewrite:*
+```
+Loading your content
+
+This usually takes 3-5 seconds.
+```
+
+*Rationale:*
+- Added expectation setting (duration)
+- Self-descriptive ("Loading your content" vs. generic)
+- Reduced uncertainty
+- Specific timeframe reduces anxiety
+- Professional, calm tone
+
+*Standards Mapping:*
+- COGA Objective 1: Clear and simple language
+- ISO 9241-110 (Conformity with expectations): User knows what to expect
+- ISO 9241-110 (Self-descriptiveness): Clear what's happening
+- WCAG 2.2.6 (Timeouts): Duration information provided
+
+---
+
+**Example 9: Application Status - Job Platform (Sensitive Context)**
+
+*Original:*
+```
+Application rejected. Better luck next time!
+```
+
+*Recommended Rewrite:*
+```
+Application status: Not selected
+
+We encourage you to apply for other open positions that match your skills. You can save this search to be notified of new opportunities.
+```
+
+*Rationale:*
+- Removed dismissive "rejected" framing
+- Eliminated "better luck" (implies chance rather than merit)
+- Provided constructive next steps
+- Offered action to maintain engagement
+- Neutral, professional tone
+
+*Standards Mapping:*
+- WCAG 3.3.3 (Error Suggestion): Next steps provided
+- ISO 9241-110 (Error tolerance): User can recover and proceed
+- COGA Objective 2: Easy to understand what happened
+- ISO/IEC 30071-1: Dignified, non-discriminatory language
+
+---
+
+**Example 10: Form Help Text - Insurance Portal (Sensitive Context)**
+
+*Original:*
+```
+Policy number (required)
+
+If you don't know your policy number, call us at 555-0123.
+```
+
+*Recommended Rewrite:*
+```
+Policy number (required)
+
+Find this on your insurance card, top right corner. It's a 9-digit number starting with "POL".
+```
+
+*Rationale:*
+- Provided specific location information (reduces memory load)
+- Included identifying characteristics (9-digit, prefix)
+- User can self-service without calling
+- Reduced cognitive burden
+- Clear, instructional tone
+
+*Standards Mapping:*
+- WCAG 3.2.6 (Consistent Help): Help is clear and accessible
+- WCAG 3.3.7 (Redundant Entry): Information location provided
+- COGA Objective 3: Reduces memory reliance
+- ISO 9241-110 (Suitability for task): Helps task completion
+
+---
+
+**Example 11: Session Timeout Warning (General Web)**
+
+*Original:*
+```
+WARNING: Your session will expire in 60 seconds! Save now or lose all your changes!
+```
+
+*Recommended Rewrite:*
+```
+Your session will expire in 5 minutes due to inactivity.
+
+Save your work to continue where you left off.
+```
+
+*Rationale:*
+- Extended warning time (5 min vs. 60 sec)
+- Removed alarming all-caps and exclamation
+- Eliminated threat ("lose all your changes")
+- Clear, single action required
+- Calm, informative tone
+
+*Standards Mapping:*
+- WCAG 2.2.6 (Timeouts): Warning of duration provided
+- ISO 9241-110 (Controllability): User has time to act
+- COGA Objective 4: Provides help without pressure
+- ISO 9241-110 (Error tolerance): Prevents data loss
+
+---
+
+**Example 12: Appointment Confirmation - Therapy Platform (Sensitive Context)**
+
+*Original:*
+```
+Congratulations! You did it! Your appointment is confirmed!
+```
+
+*Recommended Rewrite:*
+```
+Appointment confirmed
+
+Date: February 28, 2026
+Time: 2:00 PM (30 minutes)
+Provider: Dr. Smith
+
+You'll receive a reminder email 24 hours before your appointment.
+```
+
+*Rationale:*
+- Removed excessive enthusiasm
+- Provided organized, scannable details
+- Included useful next-step information
+- Calm, professional confirmation
+- Reduces anxiety about forgetting
+
+*Standards Mapping:*
+- COGA Objective 1: Clear, organized information
+- ISO 9241-110 (Self-descriptiveness): Clear what happened
+- ISO/IEC 30071-1: Accessibility includes clear communication
+- WCAG 3.3.3 (Error Suggestion): Reminder included for future action
+
+---
+
+**Example 13: Filter and Sort Options - E-commerce Search (General Web)**
+
+*Original:*
+```
+Sort: Low to High | High to Low | Relevance
+```
+(No indication of the currently active selection)
+
+*Recommended Rewrite:*
+```
+Sort results by
+
+• Price: Low to High  (currently selected ✓)
+• Price: High to Low
+• Relevance
+• Customer rating
+```
+
+*Rationale:*
+- Shows current selection explicitly (eliminates memory load)
+- Self-descriptive labels ("Price: Low to High" vs. bare "Low to High")
+- Vertical list is more scannable than horizontal tab row
+- Neutral presentation with no urgency or pressure
+
+*Standards Mapping:*
+- WCAG 2.4.6 (Headings and Labels): Labels describe purpose
+- WCAG 3.2.4 (Consistent Identification): Consistent labelling across pages
+- W3C COGA Objective 1: Clear labels reduce cognitive demand
+- ISO 9241-110 (Self-descriptiveness): Current state visible without recall
+
+---
+
+**Example 14: Destructive Action Confirmation - Account Management (Sensitive Context)**
+
+*Original:*
+```
+Delete your account?
+
+[OK]   [Cancel]
+```
+
+*Recommended Rewrite:*
+```
+Confirm account deletion
+
+Deleting your account will permanently remove:
+  • Your profile and all personal settings
+  • 14 saved items
+  • 3 active subscriptions (billing ends today)
+
+This action cannot be undone.
+
+[Keep my account]   [Permanently delete account]
+```
+
+*Rationale:*
+- Specific preview of consequences enables genuinely informed consent
+- Action-specific button labels replace ambiguous "OK" / "Cancel"
+- Plain statement of irreversibility removes false hope without alarm
+- "Keep my account" is visually and semantically the primary action
+- Neutral, factual tone — no threat language, no guilt-inducing phrasing
+
+*Standards Mapping:*
+- WCAG 3.3.4 (Error Prevention): User can review before committing
+- WCAG 2.4.6 (Headings and Labels): Buttons describe specific outcomes
+- W3C COGA Objective 2: Help users avoid irreversible mistakes
+- ISO 9241-110 (Error tolerance): User can reconsider before committing
+- ISO/IEC 30071-1: Dignified language; no coercive phrasing
+
+---
+
+**Example 15: Search Empty State - Job Board Platform (Sensitive Context)**
+
+*Original:*
+```
+0 results found.
+```
+
+*Recommended Rewrite:*
+```
+No jobs match "senior designer remote"
+
+Suggestions:
+  • Try broader keywords, such as "designer" or "UX"
+  • Remove the location filter to see all opportunities
+  • Save this search — we'll notify you when matching roles are posted
+
+[Browse all open positions]
+```
+
+*Rationale:*
+- Echoes the user's search query (confirms the system received it correctly)
+- Provides three specific, actionable next steps rather than a dead end
+- Save-search option maintains engagement without pressure
+- "Browse all" CTA is self-descriptive and recovers the task
+- No blame language; neutral factual framing
+
+*Standards Mapping:*
+- WCAG 3.3.3 (Error Suggestion): Recovery options provided
+- W3C COGA Objective 2: Easy to understand what happened
+- W3C COGA Objective 3: Help users find what they need
+- ISO 9241-110 (Error tolerance): Task can continue despite null result
+- ISO 9241-110 (Suitability for task): Interface supports alternative paths
+
+---
+
+### A.3 Localization Guidance for Depression-Sensitive Content
+
+When adapting depression-sensitive content across languages and cultures, observe the following principles to maintain emotional safety and cognitive accessibility.
+
+#### A.3.1 Language Independence Principles
+
+**Avoid Idioms and Cultural References:**
+Idioms frequently contain emotional or judgmental implications that may not translate across cultures. Depression and shame have different cultural connotations; language that feels neutral in one language may carry stigma in another.
+
+*Example:*
+- Avoid: "Don't give up!" (implies weakness/failure)
+- Use: "You can continue when ready" (neutral, supportive)
+
+**Use Literal Instruction:**
+Metaphorical language requires additional cognitive processing to decode, increasing cognitive load.
+
+*Example:*
+- Avoid: "The ball is in your court" (unclear action)
+- Use: "Your next step is to..." (clear instruction)
+
+**Maintain Formal, Professional Tone:**
+Informal registers may feel dismissive or inappropriate in sensitive contexts. Maintain consistent formality across languages.
+
+#### A.3.2 Cross-Cultural Considerations
+
+**Avoid Positive Psychology Overload:**
+Languages vary in how they express encouragement. Avoid excessive positivity, which may feel dismissive or ironic to users experiencing depression.
+
+**Honor Privacy and Autonomy:**
+Some cultures value collective decision-making; others prioritize individual autonomy. Interface language around "personal" information, "sharing," and "optional" features should be evaluated by native speakers.
+
+**Test with Native Speakers:**
+Machine translation may preserve problematic patterns. Have native speakers review for:
+- Tone appropriateness
+- Unintended shame or blame
+- Cultural sensitivity
+- Cognitive accessibility
+
+#### A.3.3 Right-to-Left (RTL) Considerations
+
+For RTL languages (Arabic, Hebrew, Persian):
+
+- Ensure scanability patterns work in RTL reading direction
+- Test error message placement (left-aligned vs. right-aligned)
+- Verify icon directionality
+- Maintain consistent visual hierarchy
+
+---
+
+## Section B: Standards Traceability Matrix
+
+This section maps each DS-WCS recommendation category to specific criteria from WCAG 2.2, W3C COGA Supplemental Guidance, ISO 9241-110:2006, and ISO/IEC 30071-1:2019. Full criterion citations are provided for authoritative reference.
+
+### B.1 Mapping Table
+
+| DS-WCS Category | WCAG 2.2 Success Criteria | W3C COGA Objectives | ISO 9241-110:2006 Principles | ISO/IEC 30071-1:2019 Clauses |
+|----------------|---------------------------|---------------------|----------------------------|----------------------------|
+| **Remove Shame/Blame Language** | **3.3.1 Error Identification (A):** "If an input error is automatically detected and the user is identified, then the error is described to the user in text."<br>**3.3.2 Labels or Instructions (A):** "Labels or instructions are provided when content requires user input." | **Objective 2: Help users avoid mistakes:** "Make it easy to understand what is wrong and how to correct mistakes. Make it easy to undo mistakes."<br>**Pattern 2.1:** "Use clear labels and instructions." | **5.4 Conformity with user expectations:** "The dialogue conforms with user expectations by being consistent and conforming to generally accepted conventions."<br>**5.7 Error tolerance:** "The dialogue is error-tolerant if, despite evident errors in input, the intended result may be achieved with no or minimal recovery effort." | **Clause 8.2:** "Accessibility policy shall address inclusive language and non-discriminatory content in all user-facing communications."<br>**Clause 9.1:** "Content shall be designed to avoid causing emotional distress." |
+| **Reduce Urgency Pressure** | **2.2.6 Timeouts (AAA):** "Users are warned of the duration of any user inactivity that could cause data loss, unless the data is preserved for more than 20 hours."<br>**3.2.5 Change on Request (AA):** "Changes to the value of any user interface component does not automatically cause a change of context unless the user has been advised of the behavior before using the component." | **Objective 4: Provide help and support:** "Make it easy to get help and have extra time if needed."<br>**Pattern 4.6:** "Avoid barriers that may cause users to make mistakes or abandon tasks." | **5.5 Controllability:** "The dialogue is controllable when the user is able to initiate and control the direction and pace of interaction to the extent needed." | **Clause 7.3:** "Design processes shall consider diverse user needs including cognitive differences that may affect task completion."<br>**Clause 8.4:** "Accessibility statements shall document time-allocation and pacing considerations." |
+| **Self-Descriptive CTAs** | **2.4.6 Headings and Labels (AA):** "Headings and labels describe topic or purpose."<br>**2.4.9 Link Purpose (Link Only) (AAA):** "A mechanism is available to allow the purpose of each link to be identified from link text alone." | **Objective 1: Help users understand what things are and how to use them:** "Use clear and simple language and provide consistent navigation."<br>**Pattern 1.3:** "Use clear and simple language." | **5.2 Self-descriptiveness:** "The dialogue is self-descriptive when each dialogue step is immediately comprehensible through feedback from the system or is annotated by the user." | **Clause 8.3:** "Content design standards shall prioritize comprehension for diverse cognitive abilities."<br>**Clause 8.4:** "Accessibility statements shall document clarity measures for interactive elements." |
+| **Error Recovery Templates** | **3.3.3 Error Suggestion (AA):** "If an input error is automatically detected and suggestions for correction are known, then the suggestions are provided to the user, unless it would jeopardize the security or purpose of the content."<br>**3.3.4 Error Prevention (AA):** "For pages that cause legal commitments or financial transactions for the user to occur, that result in the user's data being deleted or modified, the user can reverse, correct, or confirm the action." | **Objective 2: Help users avoid mistakes:** "Make it easy to understand what is wrong and how to correct mistakes."<br>**Pattern 2.5:** "Make it easy to undo mistakes." | **5.7 Error tolerance:** "The dialogue is error-tolerant if, despite evident errors in input, the intended result may be achieved with no or minimal recovery effort by the user." | **Clause 8.5:** "Document error handling and recovery procedures in accessibility logs."<br>**Clause 9.1:** "Content shall provide clear paths to recovery from error states." |
+| **Reduce Memory Reliance** | **3.3.7 Redundant Entry (A):** "Information previously entered by or provided to the user is either auto-populated or available for selection, except when re-entering information is essential, the information is required by the security settings, or the previously entered information is no longer valid."<br>**3.2.6 Consistent Help (AA):** "If a web page contains any interactive help and there is more than one web page with consistent help, the help is accessible in a consistent way." | **Objective 3: Help users find what they need:** "Make it easy to find what they need, including making it easy to navigate and providing cues to help users find what they need."<br>**Pattern 3.4:** "Avoid overwhelming the user with lots of information." | **5.3 Suitability for the task:** "The dialogue is suitable for the task when it facilitates the effective and efficient completion of the task by the user, and when it is appropriate to the user's level of experience and knowledge." | **Clause 7.2:** "Design shall minimize memory requirements for task completion."<br>**Clause 8.3:** "Content design shall present information to reduce recall demands." |
+| **Scannable Plain Language** | **3.1.5 Reading Level (AAA):** "When text requires reading ability more advanced than the lower secondary education level, supplemental content is available at a lower reading level."<br>**3.1.4 Unusual Words (AAA):** "A mechanism is available for identifying specific definitions of words or phrases used in an unusual or restricted way, including idioms and jargon." | **Objective 1: Help users understand what things are and how to use them:** "Use clear and simple language."<br>**Pattern 1.1:** "Keep content simple and clear."<br>**Pattern 3.3:** "Break information into smaller manageable chunks with clear titles." | **5.3 Suitability for the task:** "Information presentation shall be appropriate to the task and shall not include irrelevant or unnecessary information."<br>**5.2 Self-descriptiveness:** "Instructions and labels shall be self-explanatory." | **Clause 8.3:** "Content design standards shall prioritize comprehension for diverse cognitive abilities, including varying literacy levels."<br>**Clause 9.1:** "Content shall be accessible to users with varying cognitive capacities." |
+| **Calm UI Microcopy** | **2.4.11 Focus Not Obscured (Minimum) (AA):** "When a user interface component receives keyboard focus, the component is not entirely hidden by author-created content." (Visual calm supports focus)<br>**2.4.12 Focus Not Obscured (Enhanced) (AAA):** "When a user interface component receives keyboard focus, the component is not hidden by author-created content." | **Objective 4: Provide help and support:** "Provide a calm, supportive interface without pressure tactics."<br>**Pattern 4.1:** "Provide human help."<br>**Pattern 4.2:** "Give users enough time." | **5.4 Conformity with user expectations:** "The dialogue conforms with user expectations by being consistent and conforming to generally accepted conventions."<br>**5.5 Controllability:** "The dialogue supports user control of pace and direction." | **Clause 8.2:** "Accessibility policy shall address emotional safety in interface language."<br>**Clause 9.1:** "Content shall be designed to avoid causing emotional distress and shall maintain a professional, supportive tone." |
+| **Consistent Help Access** | **3.2.6 Consistent Help (AA):** "If a web page contains any interactive help and there is more than one web page with consistent help, the help is accessible in a consistent way across all those pages." | **Objective 4: Provide help and support:** "Make it easy to get help and have extra time if needed."<br>**Pattern 4.1:** "Provide human help." | **5.2 Self-descriptiveness:** "Help is available when needed and is accessible in a consistent manner." | **Clause 8.4:** "Accessibility statements shall document help and support access mechanisms." |
+| **Accessible Authentication** | **3.3.8 Accessible Authentication (Minimum) (A):** "A cognitive function test (such as remembering a password or turning a picture into a picture) is not required for any step in an authentication process unless that step provides at least one of [three exceptions]."<br>**3.3.9 Accessible Authentication (Enhanced) (AAA):** "A cognitive function test is not required for any step in an authentication process." | **Objective 3: Help users find what they need:** "Make it easy to find what they need."<br>**Objective 4:** "Provide help and support." | **5.5 Controllability:** "The dialogue supports user control of the authentication process."<br>**5.7 Error tolerance:** "The dialogue supports recovery from authentication errors." | **Clause 7.2:** "Design shall minimize cognitive load during authentication."<br>**Clause 8.5:** "Authentication processes shall be documented in accessibility statements." |
+
+### B.2 Additional WCAG 2.2 Criteria Relevant to DS-WCS
+
+The following WCAG 2.2 success criteria, while not directly mapped to DS-WCS principles above, support depression-sensitive content design and should be considered in comprehensive audits:
+
+| Criterion | Level | Relevance to DS-WCS |
+|-----------|-------|---------------------|
+| 2.4.7 Focus Visible | AA | Clear focus indicators support users with attention difficulties |
+| 2.4.11 Focus Not Obscured (Minimum) | AA | Ensures users can see where they are on the page |
+| 2.4.12 Focus Not Obscured (Enhanced) | AAA | Full visibility of focused elements |
+| 2.5.5 Target Size (Enhanced) | AAA | Larger targets (44x44px minimum) reduce frustration and errors |
+| 3.2.1 On Focus | A | No context changes on focus (prevents disorientation) |
+| 3.2.2 On Input | A | No unexpected changes on input (maintains user control) |
+| 3.3.5 Help | AAA | Context-sensitive help available |
+
+### B.3 Standards Source References
+
+**WCAG 2.2:**
+- Web Content Accessibility Guidelines (WCAG) 2.2, W3C Recommendation
+- Published: October 2023
+- URL: https://www.w3.org/TR/WCAG22/
+
+**W3C COGA:**
+- Cognitive and Learning Disabilities Accessibility Task Force
+- COGA Supplement to WCAG 2.1
+- Published: 2023
+- URL: https://w3c.github.io/coga/content-usable/
+
+**ISO 9241-110:**
+- ISO 9241-110:2006 - Ergonomics of human-system interaction - Part 110: Dialogue principles
+- International Organization for Standardization
+- URL: https://www.iso.org/standard/31975.html
+
+**ISO/IEC 30071-1:**
+- ISO/IEC 30071-1:2019 - Information technology - User interface accessibility - Part 1: Accessibility guidance for IT systems and services
+- International Organization for Standardization
+- URL: https://www.iso.org/standard/70983.html
+
+---
+
+## Section C: Audit Checklist
+
+This checklist provides structured guidance for auditing web content for depression-sensitive patterns. Each item includes a description, severity rating, examples, remediation guidance, and standards references.
+
+### Severity Rubric Definitions
+
+**HIGH Severity:**
+- Directly causes user task abandonment or prevents completion
+- Induces emotional distress or triggers shame responses
+- Violates WCAG Level A success criteria
+- May cause users to disengage from critical services (healthcare, financial, government)
+
+**MEDIUM Severity:**
+- Increases cognitive load beyond optimal levels
+- Creates emotional friction that may lead to eventual abandonment
+- Violates WCAG Level AA success criteria or ISO 9241-110 principles
+- Reduces user confidence without preventing task completion
+
+**LOW Severity:**
+- Reduces user comfort or satisfaction
+- Missed opportunity for improved accessibility
+- Does not violate standards but could be enhanced
+- May affect user perception without functional impact
+
+---
+
+### C.1 Error Messages
+
+#### C.1.1 Blame Language in Errors
+
+**Check:** Error messages attribute failure to user character, ability, or behavior in a shaming manner.
+
+**Severity:** HIGH
+
+**Examples:**
+- "You entered invalid data"
+- "You broke something"
+- "Your input is wrong"
+- "You should have read the instructions"
+- "You're too stupid to use this system"
+
+**Remediation:**
+Use system-focused language that attributes issues to format, system conditions, or input requirements rather than user characteristics.
+
+**Standards References:**
+- WCAG 3.3.1 (Error Identification)
+- WCAG 3.3.2 (Labels or Instructions)
+- ISO 9241-110 (Error tolerance, Conformity with expectations)
+- COGA Objective 2
+
+---
+
+#### C.1.2 Missing Recovery Path
+
+**Check:** Error messages lack actionable guidance on how to resolve the error.
+
+**Severity:** HIGH
+
+**Examples:**
+- "Error occurred"
+- "Invalid"
+- "Failed"
+- "Wrong password"
+- "Account not found"
+
+**Remediation:**
+Every error message shall include specific guidance on what the user should do next. Provide examples, links, or contact information as appropriate.
+
+**Standards References:**
+- WCAG 3.3.3 (Error Suggestion)
+- ISO 9241-110 (Error tolerance, Self-descriptiveness)
+- COGA Objective 2
+
+---
+
+#### C.1.3 Technical Jargon Without Explanation
+
+**Check:** Error messages use technical terminology without explanation accessible to non-technical users.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- "HTTP 500 Internal Server Error"
+- "NullPointerException"
+- "SSL handshake failed"
+- "Error code: 0x80070005"
+- "Database connection timeout"
+
+**Remediation:**
+Translate technical errors into plain language. Provide error codes for reference but lead with user-comprehensible explanations.
+
+**Standards References:**
+- WCAG 3.3.1 (Error Identification)
+- COGA Objective 1 (Clear language)
+- ISO 9241-110 (Self-descriptiveness)
+
+---
+
+#### C.1.4 Exclamation Points in Error States
+
+**Check:** Error messages use exclamation points, which increase emotional arousal.
+
+**Severity:** LOW
+
+**Examples:**
+- "Invalid email!"
+- "Password required!"
+- "Please correct errors!"
+- "Action failed!"
+- "Warning!"
+
+**Remediation:**
+Use periods instead of exclamation points in error states. Neutral punctuation supports calm processing.
+
+**Standards References:**
+- COGA Objective 4 (Calm interface)
+- ISO/IEC 30071-1 (Emotional safety)
+
+---
+
+### C.2 Call-to-Action (CTA) Buttons
+
+#### C.2.1 Non-Descriptive Button Labels
+
+**Check:** Button text uses generic commands rather than describing the outcome.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- "Submit"
+- "Click here"
+- "Go"
+- "Start"
+- "Next"
+- "Continue"
+
+**Remediation:**
+Replace generic commands with outcome descriptions that answer: "What happens when I click this?"
+
+**Standards References:**
+- WCAG 2.4.6 (Headings and Labels)
+- WCAG 2.4.9 (Link Purpose)
+- ISO 9241-110 (Self-descriptiveness)
+- COGA Objective 1
+
+---
+
+#### C.2.2 Urgency Language in CTAs
+
+**Check:** Call-to-action buttons use urgency-inducing language.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- "Sign up now!"
+- "Buy today!"
+- "Limited time offer!"
+- "Don't miss out!"
+- "Act fast!"
+
+**Remediation:**
+Remove urgency language. Use neutral time indicators or omit time references entirely.
+
+**Standards References:**
+- WCAG 3.2.5 (Change on Request)
+- ISO 9241-110 (Controllability)
+- COGA Objective 4
+
+---
+
+#### C.2.3 Ambiguous Button Groupings
+
+**Check:** Multiple buttons are presented without clear visual differentiation.
+
+**Severity:** LOW
+
+**Examples:**
+- Two similar-looking buttons with different actions
+- Primary and secondary actions with equal visual weight
+- "Cancel" button styled identically to "Submit"
+
+**Remediation:**
+Use visual hierarchy to distinguish primary (intended) actions from secondary actions. Consistent button positioning helps users predict outcomes.
+
+**Standards References:**
+- WCAG 2.4.6 (Labels)
+- ISO 9241-110 (Conformity with expectations)
+- COGA Objective 1
+
+---
+
+### C.3 Forms and Input Fields
+
+#### C.3.1 Memory-Dependent Instructions
+
+**Check:** Form instructions require users to recall information from external sources or previous interactions.
+
+**Severity:** HIGH (critical fields), MEDIUM (optional fields)
+
+**Examples:**
+- "Enter your policy number (call if you don't know it)"
+- "Input your customer ID from your welcome email"
+- "Remember your username from registration"
+
+**Remediation:**
+Provide information location guidance: "Policy number (found on your insurance card, top right)" rather than requiring memory or external contact.
+
+**Standards References:**
+- WCAG 3.3.7 (Redundant Entry)
+- WCAG 3.2.6 (Consistent Help)
+- COGA Objective 3 (Memory)
+- ISO 9241-110 (Suitability for task)
+
+---
+
+#### C.3.2 Required Field Indicators Without Explanation
+
+**Check:** Required fields are marked without clear explanation of what "required" means.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- Asterisk without legend: "*"
+- "(Required)" without explanation of what happens if not completed
+- Red asterisks without accessible labeling
+
+**Remediation:**
+Include clear instructions: "Required fields are marked with * and must be completed to proceed."
+
+**Standards References:**
+- WCAG 3.3.2 (Labels or Instructions)
+- WCAG 1.3.1 (Info and Relationships)
+- COGA Objective 1
+
+---
+
+#### C.3.3 Multi-Step Form Without Progress Indicator
+
+**Check:** Multi-step forms lack indication of current position in the flow.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- "Step 1" with no total count
+- Forms that transition without notification
+- Long forms with no section breaks
+
+**Remediation:**
+Show progress: "Step 2 of 4: Contact Information" helps users gauge time commitment and maintain context.
+
+**Standards References:**
+- WCAG 3.2.5 (Change on Request)
+- COGA Objective 3 (Find what needed)
+- ISO 9241-110 (Conformity with expectations)
+
+---
+
+#### C.3.4 Password Requirements Hidden Until Failure
+
+**Check:** Password strength requirements are only shown after submission with an invalid password.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- Password field with no visible requirements
+- Requirements shown only on validation error
+- Complex requirements without concrete examples
+
+**Remediation:**
+Display all password requirements before user input. Use inline validation with specific guidance.
+
+**Standards References:**
+- WCAG 3.3.3 (Error Suggestion)
+- WCAG 3.3.7 (Redundant Entry)
+- COGA Objective 2
+
+---
+
+#### C.3.5 Conditional Field Requirements
+
+**Check:** Form fields appear or disappear based on previous selections without clear explanation.
+
+**Severity:** HIGH
+
+**Examples:**
+- Selecting "Yes" reveals required fields without warning
+- Hidden validation messages appear after conditional selection
+- "Other" text field appears without label change
+
+**Remediation:**
+Pre-announce conditional fields: "Answering 'Yes' will show 2 additional required fields. You can skip these if not applicable."
+
+**Standards References:**
+- WCAG 3.3.2 (Labels or Instructions)
+- WCAG 3.2.2 (On Input)
+- COGA Objective 1 (Clear language)
+- ISO 9241-110 (Self-descriptiveness)
+
+---
+
+#### C.3.6 Field Grouping and Visual Organization
+
+**Check:** Related fields lack visual grouping or clear boundaries, overwhelming users with too many options.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- 20+ form fields in a single long list
+- No sections or fieldset groupings
+- Related fields scattered without visual cues
+
+**Remediation:**
+Group related fields using `<fieldset>` with `<legend>` for section headings. Break long forms into multiple steps.
+
+**Standards References:**
+- WCAG 1.3.1 (Info and Relationships)
+- COGA Objective 3 (Help users find)
+- ISO 9241-110 (Suitability for the task)
+
+---
+
+#### C.3.7 Placeholder Text Instead of Labels
+
+**Check:** Input fields use placeholder text as the only label, which disappears on focus.
+
+**Severity:** HIGH
+
+**Examples:**
+- `<input placeholder="Email address">` without visible `<label>`
+- Placeholder disappears when user starts typing
+- Empty fields without persistent labels
+
+**Remediation:**
+Use proper `<label>` elements. Placeholders should provide examples only, not replace labels.
+
+**Standards References:**
+- WCAG 3.3.2 (Labels or Instructions)
+- WCAG 1.3.1 (Info and Relationships)
+- COGA Objective 1 (Clear language)
+- ISO 9241-110 (Self-descriptiveness)
+
+---
+
+#### C.3.8 Pre-filled Data Without Explanation
+
+**Check:** Fields are auto-populated without indicating the source or that data was pre-filled.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- Address fields pre-filled from previous order with no notice
+- Username auto-populated without indication
+- Form appears to have data from previous session
+
+**Remediation:**
+Add helper text: "Using address from your last order (January 15, 2026). Edit if needed."
+
+**Standards References:**
+- WCAG 3.3.7 (Redundant Entry)
+- COGA Objective 3 (Help users find)
+- ISO 9241-110 (Conformity with expectations)
+
+---
+
+### C.4 Notifications and Alerts
+
+#### C.4.1 Excessive Urgency Markers
+
+**Check:** Notifications use alarming language, exclamation points, or urgency indicators.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- "URGENT: Action required!"
+- "ACT NOW!"
+- "LAST CHANCE!"
+- Countdown timers on cognitive tasks
+- Red text with "WARNING"
+
+**Remediation:**
+Use neutral language: "Session expiring in 5 minutes" rather than "60 seconds remaining!" Remove unnecessary urgency.
+
+**Standards References:**
+- WCAG 2.2.6 (Timeouts)
+- ISO 9241-110 (Controllability)
+- COGA Objective 4
+
+---
+
+#### C.4.2 Dismissive Tone in Negative Notifications
+
+**Check:** Negative notifications (rejections, failures) use dismissive or flippant language.
+
+**Severity:** HIGH
+
+**Examples:**
+- "Better luck next time!"
+- "Oops, wrong again!"
+- "Whoops!"
+- "Too bad, so sad"
+- "Maybe next time!"
+
+**Remediation:**
+Use neutral, informative language: "Application not selected" rather than dismissive encouragement.
+
+**Standards References:**
+- ISO/IEC 30071-1 (Dignified language)
+- COGA Objective 1 (Neutral tone)
+- ISO 9241-110 (Conformity with expectations)
+
+---
+
+#### C.4.3 Alert Fatigue
+
+**Check:** Non-critical information presented with error alert styling.
+
+**Severity:** LOW
+
+**Examples:**
+- Informational messages in error styling
+- Warnings for optional actions
+- Multiple simultaneous alerts
+
+**Remediation:**
+Use appropriate notification types: informational, success, warning, error. Reserve error styling for actionable issues.
+
+**Standards References:**
+- WCAG 3.3.1 (Error Identification)
+- COGA Objective 3 (Not overwhelming)
+
+---
+
+#### C.4.4 Stacked or Simultaneous Alerts
+
+**Check:** Multiple alerts appear simultaneously, overwhelming users and preventing comprehension.
+
+**Severity:** HIGH
+
+**Examples:**
+- 3+ error messages displayed at once without prioritization
+- Alerts that auto-dismiss before users can read them
+- Errors and warnings stacked without clear separation
+
+**Remediation:**
+Queue alerts sequentially. Prioritize by severity. Ensure each alert is dismissible and remains visible until user acknowledges.
+
+**Standards References:**
+- WCAG 2.2.4 (No Timing)
+- COGA Objective 3 (Avoid overwhelming)
+- ISO 9241-110 (Controllability)
+
+---
+
+#### C.4.5 Unclear Alert Dismissal
+
+**Check:** Alerts lack clear "Close" or "Dismiss" controls, or auto-dismiss without user control.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- Alert disappears after 3 seconds without manual dismiss
+- Close button with no accessible label
+- Toast notifications with no dismiss option
+
+**Remediation:**
+Provide clear, accessible close controls. Use `aria-label` for icon-only buttons. Allow users to control dismissal timing.
+
+**Standards References:**
+- WCAG 2.1.1 (Keyboard)
+- ISO 9241-110 (Controllability)
+- COGA Objective 4 (Provide help)
+
+---
+
+### C.5 Empty States
+
+#### C.5.1 Obligation Language
+
+**Check:** Empty states use "should," "must," or "need to" for optional actions.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- "You should add a profile picture"
+- "You must complete your profile"
+- "You need to track your mood daily"
+- "Don't forget to..."
+
+**Remediation:**
+Use optional framing: "When you [action], [content] will appear here. Optional: [suggestion]"
+
+**Standards References:**
+- COGA Objective 1 (Clear, not obligatory)
+- COGA Objective 4 (Without pressure)
+- ISO 9241-110 (Controllability)
+
+---
+
+#### C.5.2 Shame in Empty States
+
+**Check:** Empty states imply user failure or inadequacy.
+
+**Severity:** HIGH
+
+**Examples:**
+- "You haven't done anything yet"
+- "Nothing to show"
+- "You're behind on your tasks"
+- "Start achieving your goals!"
+
+**Remediation:**
+Use neutral framing: "When you [create/ add / log], [content] will appear here."
+
+**Standards References:**
+- ISO/IEC 30071-1 (Emotional safety)
+- COGA Objective 1 (Neutral tone)
+- WCAG 3.3.1 (Non-shaming)
+
+---
+
+#### C.5.3 Missing Value Proposition
+
+**Check:** Empty states don't explain why the feature is useful or how to get started.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- Blank page with no guidance
+- "No results" without search refinement suggestions
+- Empty dashboard without feature explanation
+
+**Remediation:**
+Provide context: "No activities logged. Track your daily activities to see patterns in your energy levels over time."
+
+**Standards References:**
+- WCAG 3.2.6 (Consistent Help)
+- COGA Objective 3 (Help users find)
+- ISO 9241-110 (Suitability for task)
+
+---
+
+### C.6 Onboarding and Progressive Disclosure
+
+#### C.6.1 Required Without Explanation
+
+**Check:** Onboarding steps marked as required without explaining why or consequences.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- "Complete step 1 to unlock features"
+- "Required fields must be completed now"
+- "You must provide this to continue"
+
+**Remediation:**
+Explain purpose: "Adding your preferences helps us personalize recommendations. This step is optional but recommended."
+
+**Standards References:**
+- COGA Objective 4 (Help without pressure)
+- ISO 9241-110 (Controllability)
+- WCAG 3.3.2 (Instructions)
+
+---
+
+#### C.6.2 Premature Information Disclosure
+
+**Check:** Onboarding requests extensive information before demonstrating value.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- Registration before any feature access
+- Profile completion before using product
+- Phone number required before account creation
+
+**Remediation:**
+Progressive disclosure: Allow initial access with minimal information; request additional details as value is demonstrated.
+
+**Standards References:**
+- WCAG 3.2.6 (Consistent Help)
+- COGA Objective 4 (Support without pressure)
+- ISO 9241-110 (Suitability for task)
+
+---
+
+#### C.6.3 Skipping Without Clear Consequences
+
+**Check:** "Skip" option in onboarding doesn't explain what happens or what users miss by skipping.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- "Skip this step" button with no context
+- "Skip" that hides features permanently
+- No indication of what information is optional vs. required
+
+**Remediation:**
+Use descriptive skip options: "Skip for now (you can add this later in Settings)"
+
+**Standards References:**
+- WCAG 2.4.6 (Headings and Labels)
+- COGA Objective 1 (Clear language)
+- ISO 9241-110 (Self-descriptiveness)
+
+---
+
+#### C.6.4 Unclear Progress Through Onboarding
+
+**Check:** Users don't know how many steps remain or where they are in the onboarding process.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- Multi-screen onboarding with no progress indicators
+- "Next" button with no step count
+- Back and forward navigation without context
+
+**Remediation:**
+Show progress: "Step 2 of 5: Add profile photo" with a visual progress bar.
+
+**Standards References:**
+- WCAG 2.4.8 (Location)
+- COGA Objective 3 (Help users find)
+- ISO 9241-110 (Conformity with expectations)
+
+---
+
+### C.7 Loading and Wait States
+
+#### C.7.1 Ambiguous Loading Indicators
+
+**Check:** Loading states don't indicate what is happening or expected duration.
+
+**Severity:** LOW
+
+**Examples:**
+- "Loading..." with no context
+- Spinner with no text
+- "Please wait..."
+
+**Remediation:**
+Add context: "Loading your dashboard" or "This usually takes 3-5 seconds."
+
+**Standards References:**
+- WCAG 2.2.6 (Timeouts)
+- COGA Objective 1 (Clear)
+- ISO 9241-110 (Self-descriptiveness)
+
+---
+
+#### C.7.2 Unrecoverable Loading Failures
+
+**Check:** Loading failures offer no recovery path or retry mechanism.
+
+**Severity:** HIGH
+
+**Examples:**
+- "Error loading" with no retry
+- Infinite spinner
+- Automatic redirect without explanation
+
+**Remediation:**
+Provide retry: "Unable to load. Check your connection and try again, or contact support@example.com."
+
+**Standards References:**
+- WCAG 3.3.3 (Error Suggestion)
+- ISO 9241-110 (Error tolerance)
+- COGA Objective 2
+
+---
+
+### C.8 Success and Confirmation Messages
+
+#### C.8.1 Excessive Enthusiasm
+
+**Check:** Success messages use excessive enthusiasm that may feel dismissive or ironic.
+
+**Severity:** LOW
+
+**Examples:**
+- "Congratulations!"
+- "Amazing!"
+- "You're awesome!"
+- "You did it!"
+- "Woohoo!"
+
+**Remediation:**
+Use informative confirmation: "Account created successfully. You'll receive a confirmation email shortly."
+
+**Standards References:**
+- COGA Objective 1 (Neutral tone)
+- ISO/IEC 30071-1 (Professional tone)
+
+---
+
+#### C.8.2 Missing Next Steps
+
+**Check:** Success messages don't provide guidance on what to do next.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- "Success!"
+- "Done"
+- "Completed"
+- Green checkmark with no text
+
+**Remediation:**
+Provide next steps: "Changes saved. Return to your dashboard or continue editing."
+
+**Standards References:**
+- WCAG 3.3.3 (Next steps)
+- COGA Objective 3 (Help find)
+- ISO 9241-110 (Self-descriptiveness)
+
+---
+
+### C.9 Help Text and Tooltips
+
+#### C.9.1 Hidden Help
+
+**Check:** Help is only accessible through obscure mechanisms (small icons, hidden links).
+
+**Severity:** MEDIUM
+
+**Examples:**
+- Question mark icons without labels
+- Help behind multiple clicks
+- Tooltips that disappear too quickly to read
+
+**Remediation:**
+Make help visible and persistent. Use clear labels: "Help with this form" rather than "?".
+
+**Standards References:**
+- WCAG 3.2.6 (Consistent Help)
+- WCAG 1.3.1 (Info and Relationships)
+- COGA Objective 4
+
+---
+
+#### C.9.2 Inconsistent Help Placement
+
+**Check:** Help resources are positioned inconsistently across forms or pages.
+
+**Severity:** LOW
+
+**Examples:**
+- Some fields have help text, others don't
+- Help icons in different positions
+- Inconsistent help content formats
+
+**Remediation:**
+Maintain consistent help placement and format across all forms.
+
+**Standards References:**
+- WCAG 3.2.6 (Consistent Help)
+- ISO 9241-110 (Conformity with expectations)
+
+---
+
+### C.10 Navigation and Wayfinding
+
+#### C.10.1 Disorienting Context Changes
+
+**Check:** Navigation causes unexpected context changes (new windows, automatic redirects).
+
+**Severity:** HIGH
+
+**Examples:**
+- Links that open new tabs without warning
+- Automatic redirects without user consent
+- Navigation that clears form data without warning
+
+**Remediation:**
+Warn of context changes: "Opening in new tab" or "Note: Leaving this page will clear your form."
+
+**Standards References:**
+- WCAG 3.2.1 (On Focus)
+- WCAG 3.2.2 (On Input)
+- WCAG 3.2.5 (Change on Request)
+- ISO 9241-110 (Controllability)
+
+---
+
+#### C.10.2 Inconsistent Navigation Labels
+
+**Check:** Navigation uses different terms for the same destination across pages.
+
+**Severity:** LOW
+
+**Examples:**
+- "Home" on one page, "Dashboard" on another
+- "Settings" vs. "Preferences"
+- "Profile" vs. "Account"
+
+**Remediation:**
+Maintain consistent navigation labels across the entire application.
+
+**Standards References:**
+- WCAG 3.2.6 (Consistent Help)
+- COGA Objective 1 (Consistent navigation)
+- ISO 9241-110 (Conformity with expectations)
+
+---
+
+### C.11 Confirmation Dialogs
+
+#### C.11.1 Ambiguous Confirmation Buttons
+
+**Check:** Confirmation dialogs use generic "OK/Cancel" or "Yes/No" without clear context.
+
+**Severity:** HIGH
+
+**Examples:**
+- Dialog: "Delete account?" Buttons: "Yes" | "No"
+- "Proceed?" with generic confirmation
+- Action buttons not labeled with specific outcomes
+
+**Remediation:**
+Use action-specific labels: "Delete account" | "Keep account"
+
+**Standards References:**
+- WCAG 2.4.6 (Headings and Labels)
+- ISO 9241-110 (Self-descriptiveness)
+- COGA Objective 2 (Help users avoid mistakes)
+
+---
+
+#### C.11.2 Destructive Actions Without Preview
+
+**Check:** Irreversible actions lack preview or clear explanation of consequences.
+
+**Severity:** HIGH
+
+**Examples:**
+- "Delete all data" without showing what will be deleted
+- "Cancel subscription" without showing effective date
+- "Remove" without confirming what is being removed
+
+**Remediation:**
+Show preview: "This will permanently delete: 127 files, 3 projects, 8 collaborators"
+
+**Standards References:**
+- WCAG 3.3.4 (Error Prevention)
+- ISO 9241-110 (Error tolerance)
+- COGA Objective 2 (Help avoid mistakes)
+
+---
+
+#### C.11.3 Double-Negative Confirmations
+
+**Check:** Confirmation uses confusing double-negative phrasing.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- "Don't you want to not cancel?"
+- "Disable auto-save?" with "Don't disable" button
+- "Keep current settings?" with "Don't keep" as the alternative
+
+**Remediation:**
+Use positive framing: "Turn off auto-save" | "Keep auto-save enabled"
+
+**Standards References:**
+- COGA Objective 1 (Clear language)
+- ISO 9241-110 (Conformity with expectations)
+
+---
+
+### C.12 Data Tables and Lists
+
+#### C.12.1 Sortable Columns Without Indication
+
+**Check:** Table columns can be sorted but lack visual indication of sortability or current state.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- Clickable headers with no sort indicator
+- No visual distinction between ascending/descending
+- Sort icon without accessible label
+
+**Remediation:**
+Add sort icons and accessible labels: aria-label="Sort by date (currently ascending)"
+
+**Standards References:**
+- WCAG 2.4.6 (Headings and Labels)
+- COGA Objective 1 (Clear labels)
+- ISO 9241-110 (Self-descriptiveness)
+
+---
+
+#### C.12.2 Dense Tables Without Scanability
+
+**Check:** Tables with many columns lack visual aids to help users track rows.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- Dense financial data tables without borders
+- Wide tables without alternating row colors
+- No hover highlighting to track current row
+
+**Remediation:**
+Use alternating row colors, hover highlighting, and clear borders for column separation.
+
+**Standards References:**
+- WCAG 1.4.1 (Use of Color)
+- COGA Objective 3 (Help users find)
+- ISO 9241-110 (Suitability for task)
+
+---
+
+#### C.12.3 Missing Empty State for Filtered Results
+
+**Check:** Empty search or filter results show blank table without explanation or next steps.
+
+**Severity:** MEDIUM
+
+**Examples:**
+- Search returns 0 results with empty table
+- Filters result in 0 matches with no guidance
+- "No data" without suggestions
+
+**Remediation:**
+Provide guidance: "No results for 'query'. Try different keywords or clear filters."
+
+**Standards References:**
+- WCAG 3.3.3 (Error Suggestion)
+- COGA Objective 3 (Help users find)
+- ISO 9241-110 (Error tolerance)
+
+---
+
+### C.13 Mobile-Specific Patterns
+
+#### C.13.1 Small Touch Targets
+
+**Check:** Interactive elements smaller than 44×44px on mobile interfaces.
+
+**Severity:** HIGH (mobile), MEDIUM (desktop)
+
+**Examples:**
+- Tiny close buttons (< 20px)
+- Small checkbox or radio inputs without padding
+- Compact icon buttons without adequate spacing
+
+**Remediation:**
+Ensure minimum 44×44px touch targets per WCAG 2.5.5 guidelines.
+
+**Standards References:**
+- WCAG 2.5.5 (Target Size)
+- ISO 9241-110 (Suitability for task)
+
+---
+
+#### C.13.2 Horizontal Scrolling on Mobile
+
+**Check:** Content requires horizontal scrolling or pinch-zoom to access.
+
+**Severity:** HIGH
+
+**Examples:**
+- Wide forms that scroll horizontally
+- Non-responsive tables on mobile
+- Fixed-width containers that exceed viewport
+
+**Remediation:**
+Use responsive design with content reflow. Use accordions or cards for table data.
+
+**Standards References:**
+- WCAG 1.4.10 (Reflow)
+- COGA Objective 3 (Help users find)
+- ISO 9241-110 (Suitability for task)
+
+---
+
+## Appendix: Quick Reference Cards
+
+### Error Message Quick Fix
+
+| Problem | Avoid | Use Instead |
+|---------|-------|-------------|
+| Blame | "You entered wrong data" | "Email format not recognized" |
+| No recovery | "Invalid" | "Email format not recognized. Example: name@domain.com" |
+| Urgency | "Invalid!" | "Not recognized" |
+| Jargon | "HTTP 500 Error" | "System error. Try again in 5 minutes." |
+
+### CTA Quick Fix
+
+| Problem | Avoid | Use Instead |
+|---------|-------|-------------|
+| Generic | "Submit" | "Create account" |
+| Non-descriptive | "Click here" | "View pricing" |
+| Urgency | "Sign up now!" | "Create account (2 minutes)" |
+
+### Empty State Quick Fix
+
+| Problem | Avoid | Use Instead |
+|---------|-------|-------------|
+| Obligation | "You should track daily" | "When you log activities, they'll appear here" |
+| Shame | "You haven't done anything" | "When you [action], content appears here" |
+| Missing value | "No results" | "No results for [query]. Try different keywords or browse categories." |
+
+---
+
+*Document Version: 1.0.0*
+*Last Updated: February 2026*
+*This is a UX and content accessibility resource, NOT a clinical tool. For mental health concerns, consult qualified healthcare professionals.*


### PR DESCRIPTION
## Summary

Consolidates three archived sibling repos (`wcag-aaa-web-design` 13⭐, `depression-sensitive-web-content`, `nvda-wcag22-testing`) into the existing 9 skills — no new skills added, preserving the "nine skills, not ten" rule. Also overhauls README/site discoverability (skill table above the fold, star CTA, star-history chart, one-command quick start). All three old repos are archived on GitHub with redirect READMEs funneling traffic and stars here.

## Contribution Type

- [ ] New skill
- [ ] Scenario addition to existing skill
- [ ] Bug fix (eval harness, MCP server, schemas)
- [ ] MCP action addition or update
- [x] Documentation
- [ ] Integration adapter
- [x] Other: skill reference/template consolidation from archived repos

## Impact Area

- [x] `skills/` — accessibility (10 references + 11 templates), depression-sensitive-content (implementation-guide.md)
- [ ] `mcp-servers/` — contracts, schemas, or handlers
- [ ] `evals/` — eval harness or fixtures
- [x] `docs/` — CHANGELOG, docs/marketing/ launch packs
- [ ] `.github/` — workflows or templates
- [x] `site/` — landing page skill grid + card tag styles

## Test Evidence

No TypeScript source, schemas, handlers, or eval fixtures modified — docs/markdown/templates only. CI (`pnpm check` → build → `evals` → `test:coverage`) runs on this PR; will paste output if any gate fails.

## Safety Checklist

- [x] No clinical diagnosis, treatment plans, or medical advice content (implementation-guide.md is explicitly non-clinical UX/content guidance)
- [x] No legal advice content
- [x] Safety boundaries are explicit in all modified `skill.yaml` files (unchanged; only provenance source added)
- [x] Safety-critical skills (`supportive-conversation`, `depression-sensitive-content`) include escalation language in boundaries (unchanged)
- [x] Crisis-adjacent content routes to professional resources, not AI responses

## Quality Checklist

- [ ] `pnpm check` passes (TypeScript) — CI
- [ ] `pnpm evals` passes (all 11 gates) — CI
- [ ] `pnpm test` passes (all tests) — CI
- [x] If manifesto-related, linked principle in `docs/manifesto-roadmap-map.md` and linked issue are included — N/A
- [x] New skills have at least 10 scenarios — N/A (no new skills)
- [x] Provenance and license metadata included in `skill.yaml` (`wcag-aaa-web-design` added to accessibility provenance; depression-sensitive-content already credited the source repo)
- [x] `CHANGELOG.md` updated for modified skills

## Self-Certification

By opening this PR I confirm:

- This contribution does not introduce content that could be mistaken for clinical, medical, or legal advice
- I have read `CONTRIBUTING.md` and `SECURITY.md`
- The content is original or properly attributed with a compatible license (all merged content is MIT, same author/owner — Ascent Partners Foundation)