### PR TITLE
docs: launch marketing packs + site accessibility fixes from self-audit

### DIFF
--- a/docs/marketing/devto-article-drafts.md
+++ b/docs/marketing/devto-article-drafts.md
@@ -1,441 +1,110 @@
-# Dev.to Article Drafts — DS-WCS Skill
+# Dev.to Article Drafts — Humanity4AI
 
-Three articles ready for direct posting to Dev.to. Each is written in Dev.to markdown format. Tags are listed at the top of each article — enter them in the Dev.to tag field, not in the body.
-
----
-
-## Article 1 — Technical walkthrough
-
-**Title:** How to audit your UI content for cognitive accessibility in 20 minutes
-
-**Tags:** `accessibility` `ux` `opencode` `webdev`
-
-**Cover image suggestion:** A side-by-side before/after of an error message — plain text screenshot is sufficient.
+Two articles ready for Dev.to. Enter tags in the Dev.to tag field, not the body. Publish Article 1 the week before launch; Article 2 during the launch window. Syndicate to Hashnode with canonical URL pointing to Dev.to.
 
 ---
 
-Most accessibility audits focus on colour contrast, keyboard navigation, and screen reader compatibility.
+## Article 1 — Technical deep-dive
 
-They miss the words.
+**Title:** Why I built 9 AI-agent skills with zero LLM calls — deterministic humane behavior
 
-This article walks through a 20-minute cognitive accessibility audit of a fictional checkout flow using the DS-WCS open-source skill for OpenCode. By the end you will have a working audit setup, a prioritised list of findings, and concrete rewrites to implement.
+**Tags:** `ai` `mcp` `typescript` `opensource`
 
----
-
-### What is cognitive accessibility?
-
-Cognitive accessibility addresses how well an interface works for users with conditions affecting executive function — depression, anxiety, ADHD, acquired brain injury, and others.
-
-Depression affects 280 million people globally (WHO, 2023). It impairs:
-
-- **Working memory** — holding information across steps
-- **Executive function** — planning, decision-making, task sequencing
-- **Processing speed** — absorbing and acting on information
-- **Emotional regulation** — sensitivity to shame, urgency, and negative feedback
-
-Interfaces that ignore these differences do not just create friction. They create barriers that cause task abandonment — particularly on high-stakes flows like checkout, account creation, and healthcare forms.
+**Cover image suggestion:** architecture diagram — LLM on one side, rule engine on the other, structured output between.
 
 ---
 
-### The demo component
+Every "AI safety" or "AI empathy" tool I evaluated had the same architecture: wrap the LLM in a prompt, ask it to be nice, hope for the best.
 
-Here is a fictional checkout error state. It is representative of patterns found on real production interfaces:
+Hope is not a safety boundary.
 
-```tsx
-// CheckoutError.tsx
-export function CheckoutError() {
-  return (
-    <div className="error-container">
-      <h2>Oops! Something went wrong!</h2>
-      <p>You entered invalid payment details. Please try again immediately — your cart will expire soon!</p>
-      <p>Error code: ERR_PAYMENT_422</p>
-      <button>OK</button>
-    </div>
-  );
-}
-```
+[Humanity4AI](https://github.com/humanity4ai/project_human) takes the opposite approach: 9 skills that are 100% rule-based. Regex pattern libraries, scoring functions, structured decision trees. No LLM calls, no external APIs, no network access. The LLM you're already running stays in charge of conversation — the skills adjudicate the moments that matter.
 
-Five issues visible before even running the audit:
+### The skills
 
-1. "Oops!" — dismissive opener
-2. "Something went wrong!" — vague, no recovery
-3. "You entered invalid payment details" — second-person blame
-4. "try again immediately" + "cart will expire soon" — urgency pressure stacked twice
-5. `ERR_PAYMENT_422` — technical jargon with no plain language equivalent
-6. "OK" button — generic label, no outcome description
+| Skill | Trigger moment |
+|-------|---------------|
+| Supportive Reply | User shows crisis signals |
+| Safe Content Rewriter | UI copy contains shame/urgency patterns |
+| Accessibility Audit | You need a WCAG 2.2 score, not vibes |
+| Cognitive Accessibility | Content is too dense for stressed users |
+| Cultural Context Check | Output targets an unfamiliar audience |
+| De-escalation Plan | A conversation is going hostile |
+| Empathetic Reframe | Your draft says "I understand how you feel" |
+| Neurodiversity Design | UI audit for ADHD/autism/dyslexia/sensory |
+| Age-Inclusive Design | Flow serves children or older adults |
 
----
+### What "rule-based" actually means
 
-### Install DS-WCS
+The supportive-reply skill, for example, runs:
 
-DS-WCS is an OpenCode skill. Install it project-locally:
+1. **Crisis signal detection** — 19 pattern categories (suicidal ideation, self-harm, panic, grief) matched against curated regex libraries, not model intuition
+2. **Emotion classification** — 6 categories (fear, sadness, anger, loneliness, shame, love) with confidence scoring
+3. **Risk calibration** — low/medium/high from signal density and severity
+4. **Response assembly** — supportive template + escalation guidance + localized crisis resources (988, 741741, Samaritans, IASP, findahelpline.com) across 9 languages
+5. **Mandatory disclosure** — every output carries `uncertainty: low|medium|high` and a verbatim `boundaryNotice`
+
+High risk never produces a purely generative response. The skill inserts real crisis line numbers from a single source-of-truth module — no handler is allowed to hardcode a phone number.
+
+### Why determinism wins here
+
+**Auditability.** When a crisis response goes out, you can trace exactly which pattern fired and why. Try that with a prompt chain.
+
+**Testability.** 90%+ branch coverage on safety-critical paths. Every crisis pattern has positive and negative test cases. Prompts don't have branch coverage.
+
+**Cost and latency.** Zero tokens, ~1ms, works offline in a CLI agent.
+
+**Honesty.** The WCAG auditor knows that only 41 of 86 criteria are fully automatable — so it scores those and flags the rest with `manual_reason` instead of hallucinating a pass. (Deque's own data: automation caps at ~57% of issues. The tool says this in its output.)
+
+### Try it
 
 ```bash
-mkdir -p .opencode/skills
-git clone https://github.com/simonplmak-cloud/depression-sensitive-web-content.git \
-  .opencode/skills/depression-sensitive-web-content
+npx @humanity4ai/mcp-servers
 ```
 
-Or globally, for use across all projects:
+Add to your MCP client config and all 9 skills appear as tools. Or read the skill packs as plain markdown — they work as system-prompt material too.
 
-```bash
-mkdir -p ~/.config/opencode/skills
-git clone https://github.com/simonplmak-cloud/depression-sensitive-web-content.git \
-  ~/.config/opencode/skills/depression-sensitive-web-content
-```
+GitHub: https://github.com/humanity4ai/project_human (MIT)
 
 ---
 
-### Run the audit
+## Article 2 — The consolidation story
 
-Open OpenCode in your project directory and ask:
+**Title:** My single-purpose repos got 6x the stars of my best project, so I ran the numbers and consolidated
 
-```
-Audit src/components/CheckoutError.tsx for depression-sensitive content issues
-```
-
-DS-WCS will load the skill, read the file, apply the 40-item audit checklist, and return findings organised by severity with standards citations.
+**Tags:** `opensource` `github` `career` `webdev`
 
 ---
 
-### Sample output
+My most sophisticated project — a 9-skill humane-AI toolkit with 90% test coverage, CI gates, and a published npm package — sat at 2 stars.
 
-```markdown
-## Findings
+My WCAG design-system repo, a fraction of the engineering effort, had 13.
 
-### HIGH Severity
+I dug into the data across the MCP ecosystem and the pattern is brutal: single-purpose repos dominate. WhatsApp-MCP: 5.9k stars. Firecrawl-MCP: 7k. GhidraMCP: 9.5k. Each does exactly one thing and says so in one sentence.
 
-- **CheckoutError.tsx:5** — Second-person blame language
-  - Original: "You entered invalid payment details."
-  - Standards: WCAG 3.3.1, COGA Objective 2, ISO 9241-110 Clause 5.7
+### Why single-purpose wins
 
-- **CheckoutError.tsx:5** — Stacked urgency pressure
-  - Original: "try again immediately — your cart will expire soon!"
-  - Standards: WCAG 2.2.6, ISO 9241-110 Clause 5.5, COGA Objective 4
+**3-second comprehension.** "MCP server for WhatsApp" is a complete mental model. "9 humanity skills across 6 domains" is homework.
 
-- **CheckoutError.tsx:7** — Generic button label with no outcome description
-  - Original: "OK"
-  - Standards: WCAG 2.4.6, ISO 9241-110 Clause 5.2
+**Urgency matching.** Nobody wakes up needing "humane AI." They wake up needing "my agent was rude to a user in crisis." One pain, one repo, one star.
 
-### MEDIUM Severity
+**Search surface.** Ten repos = ten READMEs, ten topic sets, ten awesome-list entries. LangChain's ecosystem holds ~240k aggregate stars across repos that would be ~140k merged.
 
-- **CheckoutError.tsx:3** — Dismissive opener with exclamation
-  - Original: "Oops! Something went wrong!"
-  - Standards: ISO/IEC 30071-1 Clause 9.1, COGA Objective 1
+### What I did about it
 
-- **CheckoutError.tsx:6** — Technical jargon without plain language
-  - Original: "Error code: ERR_PAYMENT_422"
-  - Standards: WCAG 3.3.1, COGA Objective 1
+Consolidated the three scattered repos into the toolkit — but as *content*, not new skills. The WCAG design system became reference guides and templates inside the existing accessibility skill. The depression-content repo became a 1,700-line implementation guide inside the existing content-safety skill. Old repos archived with redirect READMEs (stars preserved, traffic funneled).
 
-## Recommended Rewrites
+Then rebuilt the front door:
 
-**Before:**
-"Oops! Something went wrong! You entered invalid payment details.
-Please try again immediately — your cart will expire soon!"
+- 9-skill table above the fold (outcome per row, not feature per row)
+- One-command start: `npx @humanity4ai/mcp-servers`
+- 20 GitHub topics chosen by search volume, capped at GitHub's limit
+- Dogfooded the WCAG auditor on its own landing page — it scored 79/100 and found two real CSS bugs. That story is in this article, because self-hosting your own tool's output is the most credible demo there is.
 
-**After:**
-"Payment not processed.
+### The lesson
 
-Your card details could not be verified. Check the card number, expiry date,
-and security code, then try again.
+Quality doesn't earn stars. Comprehension speed does. Consolidate the engineering, fragment the *pitch* — every skill in my toolkit now has a one-sentence outcome you could repeat without reading the docs.
 
-Your cart is saved for 30 minutes.
+Repo: https://github.com/humanity4ai/project_human
 
-[Try payment again]  [Use a different card]"
-
-**Rationale:**
-- Removed blame attribution and exclamation points
-- Replaced stacked urgency with a calm, specific timeframe
-- Added two self-descriptive recovery actions
-- Replaced "OK" with outcome-specific button labels
-- Technical error code moved to secondary position if needed for support
-
-**Standards:**
-- WCAG 3.3.1 (Error Identification)
-- WCAG 3.3.3 (Error Suggestion)
-- WCAG 2.4.6 (Headings and Labels)
-- W3C COGA Objective 2: Help users avoid mistakes
-- ISO 9241-110: Error tolerance, Self-descriptiveness, Controllability
-```
-
----
-
-### The rewritten component
-
-```tsx
-// CheckoutError.tsx — revised
-export function CheckoutError({ cartExpiryMinutes = 30 }) {
-  return (
-    <div className="error-container">
-      <h2>Payment not processed</h2>
-      <p>
-        Your card details could not be verified. Check the card number,
-        expiry date, and security code, then try again.
-      </p>
-      <p>Your cart is saved for {cartExpiryMinutes} minutes.</p>
-      <div className="error-actions">
-        <button className="primary">Try payment again</button>
-        <button className="secondary">Use a different card</button>
-      </div>
-    </div>
-  );
-}
-```
-
----
-
-### What the audit covers
-
-DS-WCS checks 40+ items across these content categories:
-
-| Category | Example checks |
-|---|---|
-| Error messages | Blame language, missing recovery, technical jargon |
-| CTAs | Generic labels, urgency language, ambiguous groupings |
-| Forms | Memory-dependent instructions, hidden requirements, conditional fields |
-| Notifications | Urgency markers, dismissive tone |
-| Empty states | Obligation language, shame framing |
-| Onboarding | Premature disclosure, missing progress indicators |
-| Help text | Inconsistent placement, absence of inline guidance |
-
----
-
-### Install, run, contribute
-
-- **GitHub:** github.com/simonplmak-cloud/depression-sensitive-web-content
-- **Install:** One `git clone` to `.opencode/skills/`
-- **License:** MIT — free to use, fork, and extend
-- **Contributing:** 15 before/after examples already included; PRs welcome for new content categories
-
-If you audit your own interfaces and find patterns not covered by the checklist, open an issue. The goal is a community-maintained resource that covers every common interface context.
-
----
-
-## Article 2 — Conceptual explainer
-
-**Title:** Depression-sensitive design: what it is, why it matters, and how to implement it
-
-**Tags:** `accessibility` `ux` `mentalhealth` `inclusivedesign`
-
-**Cover image suggestion:** A calm, minimal interface mockup — or the DS-WCS GitHub README header.
-
----
-
-There is a category of accessibility that most teams never audit.
-
-It is not about colour contrast ratios or keyboard traps. It does not require assistive technology testing. It does not show up in automated scans.
-
-It is about the emotional and cognitive impact of the words you put on screen.
-
-This is depression-sensitive design.
-
----
-
-### What depression does to users
-
-Depression is not just sadness. It is a neurological condition that measurably impairs cognitive function, including:
-
-**Working memory** — the ability to hold information in mind across steps. A user with depression may forget what they entered three fields ago. They may lose their place in a multi-step form. They may not be able to recall a policy number they looked up 30 seconds before.
-
-**Executive function** — planning, sequencing, and decision-making. A user with depression may struggle to determine what to do next when faced with a vague error message. They may be unable to generate a recovery path independently.
-
-**Processing speed** — absorbing and acting on information. Time pressure compounds this. A countdown timer on a checkout form is not a neutral design choice for a user whose processing speed is already impaired.
-
-**Emotional regulation** — sensitivity to shame, blame, and negative feedback. A user experiencing depression is more susceptible to the emotional content of interface language. "You entered invalid data" is not a neutral statement. It attributes failure to the user. That attribution, however unintentional, can trigger a shame response that ends the session.
-
----
-
-### Seven principles
-
-Depression-sensitive design applies seven evidence-based principles to UI content:
-
-**1. Remove shame and blame language**
-Attribute errors to system conditions or input format, not the user.
-- "You entered invalid data" → "Email format not recognised"
-- "You broke something" → "Page not found"
-
-**2. Reduce urgency pressure**
-Remove countdown timers, "ACT NOW" language, and artificial scarcity from cognitive tasks.
-- "Sign up now!" → "Create account"
-- "60 seconds remaining!" → "Your session will expire in 5 minutes"
-
-**3. Self-descriptive call-to-action labels**
-Button labels should answer: "What happens when I click this?"
-- "Submit" → "Create account"
-- "OK" → "Try payment again"
-- "Go" → "Start free trial"
-
-**4. Error recovery templates**
-Every error message must answer: "What do I do now?"
-- "Invalid" → "Email format not recognised. Use this format: name@domain.com"
-- "Error occurred" → "System error. Try again in 5 minutes or contact support."
-
-**5. Reduce memory reliance**
-Display necessary information rather than requiring recall.
-- "Call for your policy number" → "Policy number (found on your insurance card, top right)"
-- Show password requirements before entry, not after failure
-
-**6. Scannable plain language**
-Short paragraphs. Bullet points. Key information first.
-- 8th grade reading level or lower for instructional content
-- Headings to break long forms into navigable sections
-
-**7. Calm UI microcopy**
-Neutral-to-supportive tone. No excessive enthusiasm or alarm.
-- "Congratulations!!!" → "Account created successfully"
-- "CRITICAL ERROR" → "System error (500)"
-- "Amazing! You did it!" → "Appointment confirmed"
-
----
-
-### The standards behind the principles
-
-These principles are not opinions. They map to four international standards:
-
-| Standard | What it covers |
-|---|---|
-| **WCAG 2.2** | Error identification, error suggestion, labels, timeouts, redundant entry |
-| **W3C COGA** | Cognitive and learning disability user needs; help users avoid mistakes, find what they need, complete tasks |
-| **ISO 9241-110** | Dialogue principles: self-descriptiveness, controllability, error tolerance, conformity with expectations |
-| **ISO/IEC 30071-1** | Accessibility policy: emotional safety, inclusive language, dignity in user-facing communications |
-
-Every finding from a DS-WCS audit maps to specific criteria in these standards. This means every change is traceable and defensible — whether for a design review, an accessibility audit, or an ESG disclosure.
-
----
-
-### Where to start
-
-A practical starting point for any team:
-
-1. Pull the last 10 error messages from your production interface
-2. Check each one against three questions:
-   - Does it use second-person blame? ("You entered", "You broke", "Your input is wrong")
-   - Does it include a recovery path?
-   - Does it use exclamation points?
-
-If any answer is yes/no/yes — you have a HIGH severity finding.
-
-The DS-WCS open-source skill automates this audit for teams using OpenCode. Install with one `git clone`, run against any component or file, and receive a findings report with standards citations and rewrite recommendations.
-
-→ github.com/simonplmak-cloud/depression-sensitive-web-content
-
----
-
-### A note on scope
-
-Depression-sensitive design is a UX and content accessibility discipline. It is not a clinical practice.
-
-DS-WCS does not diagnose depression. It does not treat depression. It does not provide mental health advice.
-
-It addresses one specific domain: the content layer of digital interfaces, and how to make that content less harmful and more usable for people with cognitive differences.
-
-That is a design responsibility, not a medical one.
-
----
-
-## Article 3 — ESG/SDG narrative for developers
-
-**Title:** Why developers should care about SDGs — and how one open-source skill connects to SDG 3
-
-**Tags:** `accessibility` `opensource` `sustainability` `webdev`
-
-**Cover image suggestion:** UN SDG colour wheel or a clean SDG 3 tile graphic.
-
----
-
-Most developers encounter ESG and SDGs in one of three contexts:
-
-1. A company all-hands where leadership announces sustainability commitments
-2. A job description that mentions "responsible tech" as a value
-3. A compliance checkbox somewhere in a procurement process
-
-In all three cases, the connection to the actual work of writing code feels abstract.
-
-This article makes it concrete. Specifically: how a free open-source tool for UI content design connects directly to UN Sustainable Development Goal 3 — and why that connection matters for the products you build.
-
----
-
-### What SDG 3 actually says
-
-SDG 3 is "Good Health and Well-Being." Most coverage focuses on vaccine access, maternal mortality, and disease prevention.
-
-Target 3.4 reads: *"By 2030, reduce by one third premature mortality from non-communicable diseases through prevention and treatment and promote mental health and well-being."*
-
-That last clause — promote mental health and well-being — applies beyond clinical settings. It applies to the environments people inhabit daily. And in 2026, those environments are increasingly digital.
-
-Digital interfaces are not neutral. The language they use, the friction they create, and the emotional tone they set have measurable effects on users with mental health conditions.
-
----
-
-### The cognitive impact of bad UX copy
-
-Depression affects approximately 280 million people globally (WHO, 2023). It impairs working memory, executive function, processing speed, and emotional regulation.
-
-When a digital interface uses blame language in error messages, it activates the brain's threat response. For users without depression, that is friction. For users with depression, that impairment compounds existing cognitive deficits — and frequently ends the session.
-
-This is not theoretical. It is documented in cognitive psychology research and referenced in standards from the W3C Cognitive Accessibility Task Force (COGA).
-
-Here are three patterns that cause measurable harm:
-
-**Blame language:** "You entered invalid data" attributes failure to the user. It induces shame, which impairs problem-solving.
-
-**Urgency pressure:** "60 seconds remaining! Act now!" creates artificial time pressure that compounds cognitive load for users whose processing speed is already impaired.
-
-**Missing recovery paths:** "Error occurred" with no next step forces users to independently generate a solution — a task that executive function impairments make genuinely difficult.
-
----
-
-### Where SDG 10 comes in
-
-SDG 10 — Reduced Inequalities — Target 10.3 addresses non-discrimination by disability status.
-
-Cognitive disabilities, including those related to depression and anxiety, are among the most prevalent disability categories globally. When digital interfaces are systematically inaccessible to users with these conditions, that is a form of structural exclusion.
-
-Fixing it is not a grand gesture. It is rewriting a button label and adding a recovery path to an error message.
-
----
-
-### The open-source connection
-
-DS-WCS (Depression-Sensitive Web Content Support) is a free OpenCode skill that automates this audit.
-
-Install it in any project:
-
-```bash
-mkdir -p .opencode/skills
-git clone https://github.com/simonplmak-cloud/depression-sensitive-web-content.git \
-  .opencode/skills/depression-sensitive-web-content
-```
-
-Ask OpenCode to audit any file:
-
-```
-Audit src/components/LoginError.tsx for depression-sensitive content issues
-```
-
-Every finding maps to WCAG 2.2, W3C COGA, ISO 9241-110, and ISO/IEC 30071-1 — the four international standards most relevant to cognitive accessibility.
-
-The repository also includes a full SDG & ESG alignment document for teams that need to surface this work in reporting.
-
----
-
-### Why this matters for open-source
-
-Open-source infrastructure underlies most of the digital interfaces people use. Libraries, frameworks, component systems, design tokens — the defaults set in open-source projects propagate across thousands of products.
-
-When error handling patterns in a component library default to blame language, that pattern ships everywhere the library ships.
-
-Open-source maintainers have disproportionate leverage over the cognitive accessibility of the web. DS-WCS gives that community a concrete, standards-backed tool for exercising that leverage responsibly.
-
----
-
-### Contribute
-
-DS-WCS is looking for contributors from accessibility, UX writing, healthcare tech, financial services, and government digital teams. The implementation guide already covers 15 content contexts. The goal is to expand that to 50+ with community input.
-
-- **Star or fork:** github.com/simonplmak-cloud/depression-sensitive-web-content
-- **Add examples:** Edit `resources/implementation-guide.md`, Section A.2
-- **Report gaps:** Open an issue describing a pattern not yet covered
-- **Use it:** Run an audit on your own interfaces and share what you find
-
-The SDGs become concrete when individual practitioners connect their daily work to them. A well-written error message is a small act. Multiplied across millions of interfaces, it is not.
+What's worked for your repos? Especially interested in awesome-list conversion rates.

--- a/docs/marketing/directory-submission-template.md
+++ b/docs/marketing/directory-submission-template.md
@@ -1,71 +1,76 @@
-# Directory Submission Template — DS-WCS Skill
+# Directory & Awesome-List Submission Pack — Humanity4AI
 
-Ready-to-use submission text for responsible tech directories, accessibility resource lists, and ESG/SDG platforms. Adapt as needed for each directory's specific form fields.
+Ready-to-use submission text for awesome lists, MCP directories, and responsible-tech catalogs. Adapt to each directory's form fields. Submit in the week before the launch window so listings land during the traffic spike.
 
 ---
 
 ## Standard Submission Block
 
 **Project Name:**
-Depression-Sensitive Web Content Support (DS-WCS)
+Humanity4AI (project_human)
 
 **Short Description (1 sentence):**
-An open-source OpenCode skill that audits and rewrites web content for cognitive accessibility, mapping every finding to WCAG 2.2, W3C COGA, ISO 9241-110, and ISO/IEC 30071-1.
+Open-source collection of 9 rule-based "humanity skills" for AI agents — crisis detection, WCAG 2.2 auditing, empathetic reframing, cultural sensitivity, and more — exposed as MCP tools and npm package.
 
 **Full Description (150 words):**
-DS-WCS is a free, open-source skill for the OpenCode AI coding agent that helps content designers, UX writers, and product teams identify and fix content patterns that create cognitive barriers or emotional distress for users with depression, anxiety, and other conditions affecting executive function.
+Humanity4AI is an open-source skill system that gives AI agents reusable, tested behaviors for humane interaction. Nine skills cover emotional safety (crisis detection + supportive replies, depression-sensitive content rewriting), accessibility (full WCAG 2.2 audit across all 86 success criteria), cognitive accessibility, cultural sensitivity, conflict de-escalation, empathetic communication, neurodiversity-aware design, and age-inclusive design.
 
-The skill applies seven evidence-based rewrite principles across error messages, CTAs, empty states, forms, notifications, and onboarding flows. Every recommendation maps to four international standards, providing audit-ready traceability for ESG disclosures, accessibility policies, and inclusive design commitments.
+All skills are rule-based — no LLM calls, no external APIs — with explicit safety boundaries, uncertainty disclosure (low/medium/high), and structured JSON-schema-validated outputs. Crisis-adjacent responses always route to professional resources, never AI substitutes.
 
-DS-WCS contributes to SDG 3 (mental health and well-being) and SDG 10 (reduced inequalities) and addresses the Social and Governance pillars of ESG frameworks. It includes a 40-item audit checklist, 15 before/after rewrite examples, and a complete standards traceability matrix.
-
-Free to install with one git clone. MIT license.
+Available as a standard MCP server (`npx @humanity4ai/mcp-servers`) compatible with Claude Code, OpenCode, Copilot, Cursor, and any MCP client, or as plain markdown skill packs usable via direct prompting. MIT license, 9 languages, 90%+ test coverage.
 
 **URL:**
-https://github.com/simonplmak-cloud/depression-sensitive-web-content
+https://github.com/humanity4ai/project_human
 
-**License:**
-MIT
+**npm:**
+https://www.npmjs.com/package/@humanity4ai/mcp-servers
+
+**License:** MIT
 
 **Category / Tags:**
-Accessibility, Cognitive Accessibility, Content Design, UX Writing, Mental Health UX, Inclusive Design, ESG Social, SDG 3, SDG 10, Neurodiversity, Responsible Tech, WCAG, W3C COGA, Developer Tools, Open Source
+MCP, Model Context Protocol, AI agents, accessibility, WCAG, mental health, content safety, inclusive design, neurodiversity, developer tools, open source, TypeScript, LLM tools, AI ethics, responsible AI
 
 **Target Users:**
-UX writers, content designers, accessibility specialists, product teams, ESG/CSR teams, healthcare and financial services teams
+AI agent developers, MCP integrators, accessibility specialists, UX/content teams, mental-health-adjacent product teams, trust & safety teams
 
 **Standards Alignment:**
-WCAG 2.2, W3C COGA Supplemental Guidance, ISO 9241-110:2006, ISO/IEC 30071-1:2019
-
-**SDG Alignment:**
-SDG 3 (Target 3.4), SDG 8 (Target 8.5), SDG 10 (Target 10.3)
+WCAG 2.2 (all 86 success criteria), W3C COGA, ISO 9241-110, ISO/IEC 30071-1, Model Context Protocol (JSON-RPC 2.0)
 
 ---
 
-## Target Directories
+## Priority Awesome Lists (GitHub PR submissions)
 
-### Accessibility
+| List | Repo | Section | Entry format |
+|------|------|---------|--------------|
+| awesome-mcp-servers | punkpeye/awesome-mcp-servers | Appropriate category (see PR) | `- [humanity4ai/project_human](url) 🎖️ 🐍/📇 ☁️/🏠 - description` |
+| awesome-a11y | brunopulis/awesome-a11y | Tools | Follow list format |
+| awesome-ai-agents | e2b-dev/awesome-ai-agents | Tools/SDKs | Follow list format |
+| awesome-llm-apps | Shubhamsaboo/awesome-llm-apps | MCP section | Follow list format |
+| awesome (sindresorhus) related niche lists | search `awesome wcag`, `awesome mental health` | — | — |
 
-| Directory | URL | Notes |
-|-----------|-----|-------|
-| The A11Y Project Resources | https://www.a11yproject.com/resources/ | Submit via GitHub PR |
-| WebAIM Resources | https://webaim.org/resources/ | Email submission |
-| Inclusive Design Institute | https://inclusivedesign.ca | Contact form |
-| W3C COGA Community Group | https://www.w3.org/community/coga-community/ | Mailing list post |
-
-### Responsible Tech / ESG
-
-| Directory | URL | Notes |
-|-----------|-----|-------|
-| Responsible Tech Guide | https://responsibletechguide.com | Submission form |
-| Tech for Good Global | https://www.techforgood.global | Directory submission |
-| B Lab Tech for Social Good | https://www.bcorporation.net | Post in B Corp community |
-| GRI Community Forums | https://community.globalreporting.org | Post in Social pillar thread |
-
-### Developer / Open Source
+## MCP Registries & Directories
 
 | Directory | URL | Notes |
 |-----------|-----|-------|
-| OpenCode Skills Gallery | https://opencode.ai | If/when skills gallery launches |
-| Awesome Accessibility (GitHub) | https://github.com/brunopulis/awesome-a11y | PR to add under Tools |
-| Product Hunt | https://www.producthunt.com | Launch post |
-| Dev.to | https://dev.to | Technical article with submission |
+| Official MCP servers repo | github.com/modelcontextprotocol/servers | PR to community servers section |
+| MCP Registry | github.com/mcp/registry (or registry.modelcontextprotocol.io) | Publish server metadata |
+| Smithery | smithery.ai | MCP server directory — submit |
+| Glama MCP directory | glama.ai/mcp/servers | Auto-indexed from GitHub; claim listing |
+| PulseMCP | pulsemcp.com | Directory + newsletter |
+| mcp.so | mcp.so | Directory submission |
+
+## Responsible Tech / Accessibility Directories
+
+| Directory | URL | Notes |
+|-----------|-----|-------|
+| The A11Y Project Resources | a11yproject.com/resources/ | Submit via GitHub PR |
+| Responsible Tech Guide | responsibletechguide.com | Submission form |
+| W3C COGA Community Group | w3.org/community/coga-community/ | Mailing list post (accessibility + cognitive skills) |
+
+---
+
+## Submission Notes
+
+- **One PR per list**, follow each list's CONTRIBUTING.md exactly (alphabetical order, badge conventions, no marketing language).
+- Lead with what it does in one clause; maintainers reject vague entries.
+- Don't submit to all lists on the same day — spread across the pre-launch week so each merge is a separate touchpoint.

--- a/docs/marketing/launch-plan.md
+++ b/docs/marketing/launch-plan.md
@@ -1,0 +1,69 @@
+# Launch Plan — Humanity4AI 48-Hour Window
+
+GitHub Trending ranks by star velocity, not total stars. A coordinated 48-hour multi-channel push is worth ~5x the same effort spread over two weeks. This plan sequences every asset in `docs/marketing/`.
+
+**Pick a Tuesday or Wednesday start.** Avoid weekends, holidays, and major tech-event days (Apple/Google keynotes, AWS re:Invent).
+
+---
+
+## Pre-Launch (T-7 to T-1 days)
+
+- [ ] **T-7:** Publish Dev.to Article 1 ("Why I built 9 AI-agent skills with zero LLM calls") — seeds the story before launch traffic arrives
+- [ ] **T-6:** Submit awesome-list PRs (see directory-submission-template.md) — stagger across T-6 to T-2 so merges land during launch week
+- [ ] **T-5:** Post in 2-3 relevant communities as a genuine participant (not promoting) — build subreddit karma if the account is new to r/accessibility
+- [ ] **T-3:** Syndicate Article 1 to Hashnode (canonical → Dev.to)
+- [ ] **T-2:** Verify all links live: repo README renders, npm page loads, site loads at humanity4ai.simonmak.com, archived repos show redirects
+- [ ] **T-1:** Prepare Product Hunt listing (logo, 5 screenshots, tagline: "9 humanity skills for AI agents — crisis detection, WCAG audits, empathy"). Schedule for 12:01 AM PT launch day. Line up a Hunter if possible.
+- [ ] **T-1:** Final check: `pnpm check && pnpm evals && pnpm test` green on main (run in Codespace)
+
+## Day 1 (Launch Tuesday/Wednesday)
+
+| Time (ET) | Channel | Asset |
+|-----------|---------|-------|
+| 8:00–10:00 AM | **Hacker News** — Show HN | Title: `Show HN: Humanity4AI – 9 rule-based humanity skills for AI agents (MCP, zero LLM calls)`. First comment within 5 min: why you built it (the "agent replies with a stack trace" story) + what's deterministic vs LLM-based. Respond to every comment within 30 min for the first 6 hours. |
+| 9:00 AM | **X/Twitter** — launch thread | 7-post thread from x-twitter-content-pack.md. Pin it. |
+| 10:00 AM | **LinkedIn** — Post 1 | Link in first comment. |
+| 11:00 AM | **Reddit** — r/accessibility | Post 1 from reddit-post-pack.md (the dogfooding story leads). |
+| Afternoon | Engage | Answer every HN/Reddit/X reply. No new posts — depth over breadth. |
+
+## Day 2
+
+| Time (ET) | Channel | Asset |
+|-----------|---------|-------|
+| 12:01 AM PT | **Product Hunt** | Listing goes live. Ask supporters to upvote/comment early (PH weights first-hours velocity). |
+| 9:00 AM ET | **Reddit** — r/LocalLLaMA or r/artificial | Post 2 (deterministic skills angle). |
+| 12:00 PM | **Dev.to** — Article 2 | The consolidation story. Link the HN thread if it's going well. |
+| 3:00 PM | **Reddit** — r/webdev | Post 3 (consolidation/lessons angle) — only if Day 1 posts weren't removed/flagged; otherwise skip to avoid spam signals. |
+
+## Day 3–7 (Compounding)
+
+- [ ] LinkedIn Post 2 (thought leadership)
+- [ ] X standalone posts A–D, one per day
+- [ ] Reply to every issue/discussion opened during launch within 24h
+- [ ] Track: stars (star-history.com), npm downloads, referral traffic (GitHub Insights → Traffic)
+- [ ] If GitHub Trending hits (TypeScript or all-languages): screenshot it, post it everywhere — Trending is self-reinforcing
+
+## Success Metrics
+
+| Metric | Conservative | Good | Great |
+|--------|-------------|------|-------|
+| Stars after 7 days | 50 | 200 | 1,000+ (Trending) |
+| HN front page | — | 4+ hours | #1-10 |
+| npm weekly downloads | 50 | 300 | 1,000+ |
+| Awesome-list merges | 1 | 3 | 5+ |
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| HN flags it as self-promo | First comment is the genuine story; no marketing language in title; "rule-based, zero LLM calls" is the hook — contrarian enough to earn discussion |
+| Reddit removal | Text posts, community-first framing, no link-only posts, one post per sub per day max |
+| Mental-health topic attracts trolls | Respond once with the non-clinical boundary statement; never debate clinical validity — the repo's safety position is documented |
+| Launch window collides with big tech news | Check the tech calendar at T-3; slide the window if a keynote lands on Day 1 |
+
+## After Launch (Week 2+)
+
+- [ ] Write the retrospective post (what worked, star data) — this content itself performs well
+- [ ] Convert engaged commenters into contributors: label beginner-friendly items `good first issue`
+- [ ] Evaluate spinning out `humanity4ai-mcp` as its own repo once total stars pass ~500 (aggregate-org-stars strategy)
+- [ ] Product Hunt can be re-launched for major versions — keep the listing maintained

--- a/docs/marketing/linkedin-content-pack.md
+++ b/docs/marketing/linkedin-content-pack.md
@@ -1,173 +1,74 @@
-# LinkedIn Content Pack — DS-WCS Skill
+# LinkedIn Content Pack — Humanity4AI
 
-Five ready-to-post LinkedIn updates. Each is self-contained and can be posted independently. The recommended sequence is Posts 1–3 in weeks 1–2, then Posts 4–5 in weeks 3–5.
-
----
-
-## Post 1 — Skill Announcement (Week 1)
-
-**Target audience:** ESG practitioners, product teams, accessibility specialists, OpenCode users
-
-```
-We just open-sourced a free tool for product teams building more inclusive digital experiences.
-
-Depression-Sensitive Web Content Support (DS-WCS) is an OpenCode skill that audits and rewrites UI content — error messages, CTAs, forms, empty states — for cognitive accessibility.
-
-Every finding maps to four international standards:
-• WCAG 2.2
-• W3C COGA
-• ISO 9241-110
-• ISO/IEC 30071-1
-
-It advances SDG 3 (mental health and well-being) and SDG 10 (reduced inequalities) — and contributes directly to the Social pillar of ESG frameworks.
-
-One git clone. Works inside OpenCode. Zero cost.
-
-→ github.com/simonplmak-cloud/depression-sensitive-web-content
-
-#ESG #SDG #CognitiveAccessibility #InclusiveDesign #ResponsibleTech #WCAG #OpenSource
-```
+Two posts: a launch announcement (Day 1) and a thought-leadership follow-up (Day 4-5). LinkedIn rewards professional framing — lead with the problem and the engineering discipline, not the star count.
 
 ---
 
-## Post 2 — Before/After Rewrite Examples (Week 1–2)
+## Post 1 — Launch Announcement
 
-**Target audience:** UX writers, content designers, product managers
+**Format:** Text + link preview (put the GitHub link in the first comment, not the post body — LinkedIn deprioritises posts with external links)
 
-```
-Your error messages may be driving users away — not because of bugs, but because of language.
+**Body:**
 
-Here are 3 real rewrites from our open-source DS-WCS content audit framework:
+AI agents write our code, answer our customers, and increasingly talk to people in vulnerable moments.
 
----
+But when a user tells an agent "I can't do this anymore," most agents respond with whatever the model feels like generating.
 
-BEFORE: "Invalid email! Try again."
-AFTER: "Email format not recognized. Please use this format: name@domain.com"
+Over the past months I've been building Humanity4AI — an open-source system of 9 "humanity skills" for AI agents:
 
----
+→ Crisis detection with supportive replies that always escalate to real helplines (988, Samaritans, IASP — in 9 languages)
+→ WCAG 2.2 accessibility auditing across all 86 success criteria
+→ Depression-sensitive content rewriting, mapped to WCAG, W3C COGA, and ISO standards
+→ Cultural sensitivity checks with mandatory uncertainty disclosure
+→ Conflict de-escalation planning
+→ Empathetic communication reframing
+→ Neurodiversity-aware and age-inclusive design audits
 
-BEFORE: "You broke something. This page doesn't exist."
-AFTER: "Page not found. Check the URL for typos, or return to the homepage."
+Two engineering decisions I'm most confident about:
 
----
+1. **Zero LLM calls.** Every skill is rule-based — pattern libraries and scoring functions. Deterministic, auditable, and testable (90%+ branch coverage on safety-critical paths). You can't put a prompt chain under branch coverage.
 
-BEFORE: "Application rejected. Better luck next time!"
-AFTER: "Application status: Not selected. You can apply for other open positions that match your skills."
+2. **Mandatory humility.** Every output declares its uncertainty (low/medium/high) and its safety boundary — what the skill will never do, including diagnosing, treating, or claiming legal compliance.
 
----
+The system runs as a standard MCP server — one command, compatible with Claude Code, Copilot, Cursor, OpenCode, and any MCP client.
 
-The difference isn't just tone. Research shows shame-inducing language activates the brain's threat response, impairing executive function and triggering task abandonment — particularly for users experiencing depression.
+MIT licensed. Contributions, scenarios, and critiques welcome — especially from accessibility practitioners and mental-health-adjacent product teams.
 
-280 million people globally live with depression (WHO). They use your product.
+(Link in comments)
 
-Full rewrite library (15 before/after examples, 40-item audit checklist):
-→ github.com/simonplmak-cloud/depression-sensitive-web-content
-
-#UXWriting #ContentDesign #CognitiveAccessibility #InclusiveDesign #ESG #MentalHealthUX
-```
+#ResponsibleAI #Accessibility #OpenSource #AIAgents #InclusiveDesign
 
 ---
 
-## Post 3 — ESG Social Pillar Angle (Week 2)
+## Post 2 — Thought Leadership (Day 4-5)
 
-**Target audience:** ESG/CSR teams, sustainability leads, responsible tech advocates
+**Format:** Text only, no link (link in comments)
 
-```
-Most ESG Social disclosures focus on supply chain, workforce diversity, and community investment.
+**Body:**
 
-Very few mention cognitive accessibility in digital products.
+A lesson from shipping open-source AI tooling: my most carefully engineered project had 2 GitHub stars. A far simpler side project had 6x more.
 
-That's a gap worth closing.
+The data across the ecosystem explains why. Single-purpose tools dominate — the top MCP servers each do exactly one thing and say so in one sentence. Comprehensive toolkits, however well-built, fail the 3-second comprehension test.
 
-Depression affects 280 million people globally. Cognitive differences — including those caused by anxiety, ADHD, and executive function impairments — are among the most common disabilities in the world.
+So I ran the experiment:
 
-When your digital interfaces use blame language, urgency pressure, or memory-dependent instructions, you are systematically excluding a significant portion of your users. That is a Social pillar issue.
+1. Consolidated three scattered repos into the main toolkit — as enriched content, not new features
+2. Archived the old repos with redirect notices (stars preserved, traffic funneled)
+3. Rebuilt the README around a table of outcomes, not a wall of features
+4. Dogfooded the WCAG auditor on its own site — it scored 79/100 and found two genuine bugs. Fixed them, and that story became the demo.
 
-The Depression-Sensitive Web Content Support (DS-WCS) framework gives product teams:
-• A 40-item content audit checklist
-• 15 before/after rewrite examples
-• Standards traceability to WCAG 2.2, W3C COGA, ISO 9241-110, and ISO/IEC 30071-1
-• Alignment documentation for GRI, SASB, B Corp, and UN Global Compact reporting
+Early results: the redirect traffic alone now exceeds the original organic traffic.
 
-It's open source, free to use, and maps directly to SDG 3 and SDG 10.
+The deeper point for engineering leaders: quality and discoverability are separate workstreams. The best code in your portfolio is worthless if a stranger can't articulate what it does in 3 seconds. Consolidate the engineering; fragment the pitch.
 
-SDG & ESG alignment documentation:
-→ github.com/simonplmak-cloud/depression-sensitive-web-content/blob/main/docs/sdg-esg-alignment.md
+What's worked for your projects?
 
-#ESG #SocialImpact #SDG3 #SDG10 #DEI #Neurodiversity #DigitalEquity #ResponsibleTech
-```
+#OpenSource #EngineeringLeadership #DevRel
 
 ---
 
-## Post 4 — Standards Traceability as ESG Evidence (Week 3–4)
+## Engagement Notes
 
-**Target audience:** ESG reporting teams, governance leads, compliance officers
-
-```
-"We are committed to inclusive design."
-
-That sentence appears in a lot of ESG reports.
-
-What's rarer: audit-ready evidence of what that commitment looks like in practice.
-
-The DS-WCS skill generates findings in this format:
-
----
-Finding: Blame language in error message
-File: src/components/checkout/ErrorState.tsx:42
-Original: "You entered invalid card details."
-Standards: WCAG 3.3.1 (Error Identification) | COGA Objective 2 | ISO 9241-110 Clause 5.7 | ISO/IEC 30071-1 Clause 9.1
----
-
-Every finding is traceable to a specific clause in a specific standard.
-
-That's the kind of documentation that belongs in an ESG Social disclosure — not just a statement of intent, but a record of what was found, what was fixed, and which international standards guided the decision.
-
-DS-WCS is free, open source, and requires one git clone to install.
-
-→ github.com/simonplmak-cloud/depression-sensitive-web-content
-
-#ESG #Governance #AccessibilityAudit #WCAG #ContentDesign #InclusiveDesign #SDG10
-```
-
----
-
-## Post 5 — Contributor & Fork Invitation (Week 4–5)
-
-**Target audience:** Accessibility community, UX writers, responsible tech practitioners, open-source contributors
-
-```
-DS-WCS is an open-source OpenCode skill for depression-sensitive content design.
-
-It already covers:
-• 7 core rewrite principles
-• 15 before/after examples across healthcare, finance, e-commerce, and government contexts
-• 40+ audit checklist items
-• Full standards traceability to WCAG 2.2, W3C COGA, ISO 9241-110, and ISO/IEC 30071-1
-
-We are looking for contributors from the accessibility, UX writing, and responsible tech communities to help expand it.
-
-If you work in:
-• Content design or UX writing
-• Accessibility consulting
-• Mental health technology
-• Healthcare or financial services UX
-• ESG / responsible product development
-
-...your domain knowledge belongs in this resource.
-
-Fork instructions, contribution guidelines, and the full implementation guide are in the repository.
-
-→ github.com/simonplmak-cloud/depression-sensitive-web-content
-
-#OpenSource #AccessibilityContributions #UXWriting #CognitiveAccessibility #ResponsibleTech #ESG #SDG #InclusiveDesign
-```
-
----
-
-## Posting Notes
-
-- Recommended cadence: one post every 5–7 days
-- Tag 2–3 relevant people or organizations in each post where appropriate (accessibility leads, ESG practitioners, OpenCode community)
-- Engage with comments within the first 60 minutes of posting to boost algorithmic reach
-- Posts 2 and 4 perform well as carousel formats — the before/after structure translates directly to slides
+- Respond to every comment within 2 hours during launch week — LinkedIn's algorithm weights early comment velocity heavily
+- Repost to relevant groups: Accessibility professionals, Responsible AI, AI Ethics communities
+- If Ascent Partners Foundation has a LinkedIn page, publish Post 1 there and reshare from the personal account

--- a/docs/marketing/reddit-post-pack.md
+++ b/docs/marketing/reddit-post-pack.md
@@ -1,157 +1,93 @@
-# Reddit Post Pack — DS-WCS Skill
+# Reddit Post Pack — Humanity4AI
 
-Three posts, one per subreddit. Each is written community-first — the value (resource, examples, discussion) leads; the project link is secondary. Reddit penalises posts that read as self-promotion. These are framed as contributions to the community.
+Three posts, one per subreddit. Community-first framing: the insight/resource leads; the link is secondary. Reddit penalises self-promotion. Post these inside the 48-hour launch window (see launch-plan.md). Build karma in each sub before posting if the account is new there.
 
 ---
 
 ## Post 1 — r/accessibility
 
-**Subreddit:** r/accessibility
-**Post type:** Text post (no link post — text posts perform better in this sub)
-**Title:** Free cognitive accessibility audit checklist for UI content — 40 items, maps to WCAG 2.2 and W3C COGA
-
----
-
-**Body:**
-
-I put together an open-source audit framework for cognitive accessibility in UI content — specifically for the content layer that most accessibility audits skip: error messages, CTAs, empty states, form instructions, notifications, and onboarding flows.
-
-It covers 40+ audit items across those categories, with severity ratings (HIGH/MEDIUM/LOW), remediation guidance, and full traceability to WCAG 2.2, W3C COGA, ISO 9241-110, and ISO/IEC 30071-1 for every finding.
-
-A few examples of what it catches:
-
-**HIGH severity:**
-- Blame language in error messages ("You entered invalid data" → attribute to format, not user)
-- Missing recovery paths ("Error occurred" with no next step)
-- Placeholder text used as the only label (disappears on focus, violates WCAG 3.3.2)
-- Conditional fields that appear without warning
-
-**MEDIUM severity:**
-- Generic button labels ("Submit", "OK", "Go") — violates WCAG 2.4.6
-- Password requirements hidden until after failure
-- Multi-step forms with no progress indicator
-- Memory-dependent form instructions ("Call us for your policy number")
-
-**LOW severity:**
-- Exclamation points in error states
-- Excessive enthusiasm in confirmations ("Congratulations!!! You did it!!!")
-
-The checklist is in a GitHub repo along with a 15-example before/after rewrite library and a full standards traceability matrix.
-
-Would be interested in feedback from practitioners on gaps — particularly for native app contexts, voice interfaces, or domains I haven't covered well (e.g., education platforms, government services).
-
-→ https://github.com/simonplmak-cloud/depression-sensitive-web-content
-
----
-
-## Post 2 — r/UXDesign
-
-**Subreddit:** r/UXDesign
 **Post type:** Text post
-**Title:** 15 before/after UI content rewrites for cognitive accessibility — looking for critique
-
----
+**Title:** I built a rule-based WCAG 2.2 auditor that runs inside AI agents (MCP) — all 86 success criteria, no API calls
 
 **Body:**
 
-I've been building an open-source audit framework for cognitive accessibility in UI content and wanted to share the rewrite library here for critique. These are the patterns I see most frequently in audits — interested to know if practitioners here agree with the rewrites or would approach them differently.
+Most AI accessibility tooling sends your HTML to an LLM and asks "is this accessible?" The answer is non-deterministic and unverifiable.
 
-Here are 5 of the 15 examples:
+I took a different approach: a fully rule-based engine that scores pages against all 86 WCAG 2.2 success criteria (A/AA/AAA, all four POUR principles). Regex + structured heuristics only — zero LLM calls, zero network requests. Same input, same output, every time.
 
----
+What it does:
 
-**Error message — e-commerce checkout:**
-Before: "Invalid email! Try again."
-After: "Email format not recognised. Please use this format: name@domain.com"
+- **Crawl mode:** feed it `{url, html}` pairs, get a 0–100 score per criterion, per page, plus site aggregate and ranking
+- **Session mode:** declare your target level (A/AA/AAA), get the full checklist the agent must enforce
+- Honest about limits: the 41 fully automatable criteria get real scores; manual-only criteria (e.g., audio description) are flagged with a `manual_reason` instead of being fake-passed
+- Optional axe-core engine if you want Deque's rules too (~57% automation ceiling — it says so in the output)
 
-Rationale: Removes blame attribution, removes exclamation point, provides concrete recovery path and format example.
+It's one of 9 "humanity skills" in the project (the others cover cognitive accessibility, neurodiversity-aware design, depression-sensitive content). Everything is MIT licensed and runs as a standard MCP server:
 
----
+```
+npx @humanity4ai/mcp-servers
+```
 
-**Empty state — wellness app:**
-Before: "No activities logged. You should track your mood daily to see your progress over time."
-After: "When you log activities, they'll appear here. Optional: track your mood to identify patterns in your energy and wellbeing."
+I ran it on its own landing page and it scored itself 79/100 at AAA — the failing criteria were instructive (no `line-height ≥ 1.5` in body CSS, touch targets under 44px). Dogfooding found real bugs.
 
-Rationale: Removes "should" (obligation language), removes "progress" (implies current failure), emphasises optionality.
+Feedback wanted: which WCAG criteria do you most want deterministic automation for that everyone leaves manual?
 
----
-
-**CTA — account signup:**
-Before: "Sign up now!"
-After: "Create your account (takes about 2 minutes)"
-
-Rationale: Self-descriptive outcome, time expectation reduces uncertainty, no urgency pressure.
+→ https://github.com/humanity4ai/project_human
 
 ---
 
-**Session timeout — general web:**
-Before: "WARNING: Your session expires in 60 seconds! Save now or lose all your changes!"
-After: "Your session will expire in 5 minutes due to inactivity. Save your work to continue."
+## Post 2 — r/LocalLLaMA (or r/artificial)
 
-Rationale: Extended warning window, removed caps and exclamation points, removed threat language, single calm action.
-
----
-
-**Job application rejection — job platform:**
-Before: "Application rejected. Better luck next time!"
-After: "Application status: Not selected. You can apply for other open positions that match your skills."
-
-Rationale: Removed "rejected" framing, removed "luck" (implies random outcome), provided constructive next step.
-
----
-
-All 15 rewrites map to WCAG 2.2, W3C COGA, ISO 9241-110, and ISO/IEC 30071-1 — so the rationale isn't subjective, it's grounded in the relevant standards.
-
-The full library, audit checklist, and standards traceability matrix are in the repo if anyone wants to dig in:
-→ https://github.com/simonplmak-cloud/depression-sensitive-web-content
-
-Happy to discuss any of the rewrites — particularly cases where the before version might be appropriate in certain contexts, or where the after version introduces new problems.
-
----
-
-## Post 3 — r/opensource
-
-**Subreddit:** r/opensource
 **Post type:** Text post
-**Title:** DS-WCS — open-source OpenCode skill for cognitive accessibility audits in UI content [MIT]
-
----
+**Title:** 9 rule-based "humanity skills" for LLM agents — crisis detection, de-escalation, empathy checks, all deterministic, all local
 
 **Body:**
 
-**What it is:**
-An OpenCode agent skill that audits and rewrites UI content for cognitive accessibility. It targets the content layer — error messages, CTAs, form instructions, empty states, notifications — that most accessibility tools don't cover.
+A pattern I kept hitting: agents are fine at code and terrible at humans. A user says "I can't do this anymore" and the agent responds with a stack trace.
 
-**How it works:**
-Install with one `git clone` into your `.opencode/skills/` directory. Ask OpenCode to audit any file or content snippet. It returns prioritised findings with standards citations (WCAG 2.2, W3C COGA, ISO 9241-110, ISO/IEC 30071-1) and before/after rewrite recommendations.
+So I built 9 rule-based skills that run inside any MCP-compatible agent (Claude Code, OpenCode, Copilot, Cursor):
 
-```bash
-mkdir -p .opencode/skills
-git clone https://github.com/simonplmak-cloud/depression-sensitive-web-content.git \
-  .opencode/skills/depression-sensitive-web-content
-```
+1. **Supportive reply** — detects crisis signals across 6 emotion categories, generates a supportive response, and always escalates to real crisis lines (988, 741741, Samaritans, IASP — localized, 9 languages). High-risk input never gets a purely AI response.
+2. **Depression-sensitive content rewriter** — flags shame/blame/urgency patterns in UI copy and rewrites them, mapped to WCAG 2.2 + COGA + ISO standards.
+3. **WCAG 2.2 audit** — all 86 success criteria, regex engine + optional axe-core.
+4. **Cognitive accessibility audit** — reading level, structure, cognitive load.
+5. **Cultural context check** — sensitivity flags for a stated audience/region, with uncertainty disclosure.
+6. **De-escalation plan** — structured plans by intensity (low/medium/high), explicitly non-coercive.
+7. **Empathetic reframe** — catches hollow empathy ("I understand how you feel") and rewrites it.
+8. **Neurodiversity design check** — ADHD/autism/dyslexia/sensory UI audit.
+9. **Age-inclusive design check** — barriers for children through older adults.
 
-Then in OpenCode:
-```
-Audit src/components/ErrorState.tsx for depression-sensitive content issues
-```
+Design decisions that might interest this sub:
 
-**What's in the repo:**
-- `SKILL.md` — main skill definition loaded by OpenCode
-- `resources/implementation-guide.md` — 7 core rewrite principles, 15 before/after examples, 40-item audit checklist, full standards traceability matrix
-- `AGENTS.md` — agent context and auto-invocation triggers
-- `docs/` — SDG/ESG alignment documentation, fork instructions
+- **No LLM in the loop.** Every skill is patterns + heuristics. Deterministic, auditable, zero token cost, works offline. The LLM orchestrates; the skill adjudicates.
+- **Uncertainty is mandatory output.** Every response states low/medium/high confidence. Cultural checks default to high uncertainty.
+- **Safety boundaries are machine-readable.** Each skill declares what it will never do (no diagnosis, no therapy, no legal compliance claims).
 
-**License:** MIT
+MIT, TypeScript, 90%+ test coverage: https://github.com/humanity4ai/project_human
 
-**Looking for contributors:**
-The implementation guide currently covers general web, e-commerce, healthcare, financial services, and job platform contexts. Would like to expand to:
-- Education platforms
-- Government / public sector services
-- Native mobile (iOS/Android content patterns)
-- Voice interfaces
-- Additional language/localization examples
+What humane failure modes have you hit with your agents? Genuinely asking — scenarios become test fixtures.
 
-If you work in any of these domains and want to add before/after examples or audit checklist items, the contribution guide is in `.github/CONTRIBUTING.md`.
+---
 
-→ https://github.com/simonplmak-cloud/depression-sensitive-web-content
+## Post 3 — r/webdev (or r/opensource)
+
+**Post type:** Text post
+**Title:** I consolidated my scattered accessibility/mental-health repos into one MCP toolkit — here's what the star data taught me
+
+**Body:**
+
+I maintained separate repos for a WCAG design system, a depression-sensitive content skill, and an NVDA testing pipeline. The single-purpose WCAG repo got 6x the stars of my comprehensive toolkit — matching the pattern you see across GitHub (single-purpose MCP servers like WhatsApp-MCP and Firecrawl hit thousands of stars while polished multi-tool repos sit at zero).
+
+So I ran the experiment properly: consolidated everything into one coherent project (9 skills, one MCP server, one npm package), archived the old repos with redirects, and rebuilt the README around a 3-second comprehension test.
+
+What actually moved the needle, ranked:
+
+1. **A skills table above the fold.** "9 humanity skills" is abstract. A 9-row table with one-line outcomes is not.
+2. **One-command install.** `npx @humanity4ai/mcp-servers` replaced a 5-step setup.
+3. **20 precise topics** (mcp-server, llm, claude, openai, wcag) — GitHub caps at 20; dropping vanity topics for search-volume topics matters.
+4. **Archiving old repos with redirect READMEs** instead of deleting — the stars stay visible and funnel traffic.
+5. **Dogfooding the tool on itself** — the WCAG auditor scored its own landing page 79/100 and found real issues (missing line-height, small touch targets). That story is better marketing than any feature list.
+
+The toolkit: https://github.com/humanity4ai/project_human (MIT)
+
+Happy to share the full before/after README diff if anyone's doing the same consolidation.

--- a/docs/marketing/x-twitter-content-pack.md
+++ b/docs/marketing/x-twitter-content-pack.md
@@ -1,301 +1,106 @@
-# X / Twitter Content Pack — DS-WCS Skill
+# X / Twitter Content Pack — Humanity4AI
 
-Four threads, written tweet-by-tweet. Each tweet is numbered. The first tweet is the hook — it must stand alone if the thread is not expanded. End each thread by replying to tweet 1 with tweet 2, then continuing in sequence.
-
-Character limit: 280 per tweet. All tweets below are within limit.
+Post the launch thread on Day 1 of the 48-hour window (see launch-plan.md). Follow with the standalone posts over the next week. Pin the thread.
 
 ---
 
-## Thread 1 — "7 error messages that silently lose users"
+## Launch Thread (7 posts)
 
-**Target audience:** Developers, UX designers, product managers
-**Best posting time:** Tuesday or Wednesday, 9–11am
+**1/7**
+AI agents are everywhere. Humane ones aren't.
 
----
+A user tells your agent "I can't do this anymore" — and it replies with a stack trace.
 
-**Tweet 1 (hook):**
-7 error messages that silently lose users — and what to write instead.
+I built 9 rule-based "humanity skills" that fix this. Open source, MIT, zero LLM calls. 🧵
 
-(A thread on cognitive accessibility and why your content is doing more damage than your bugs.)
+https://github.com/humanity4ai/project_human
 
----
+**2/7**
+The core idea: don't ask the LLM to be humane. Adjudicate it.
 
-**Tweet 2:**
-1/ "Invalid email! Try again."
+Every skill is patterns + heuristics — deterministic, testable, auditable. The LLM converses; the skills govern the moments that matter.
 
-The exclamation point raises emotional arousal. "Invalid" attributes failure to the user. There's no recovery path.
+No API calls. No tokens. ~1ms.
 
-Rewrite: "Email format not recognized. Use this format: name@domain.com"
+**3/7**
+The 9 skills:
 
----
+🛡️ Crisis detection → supportive reply + real helplines (9 languages)
+📝 Shame/urgency content rewriter
+♿ WCAG 2.2 audit (all 86 criteria)
+🧠 Cognitive accessibility
+🌍 Cultural context checks
+🔥 De-escalation plans
+💬 Empathy reframing
+🧩 Neurodiversity design
+👶 Age-inclusive design
 
-**Tweet 3:**
-2/ "You broke something. This page doesn't exist."
+**4/7**
+The safety rule that matters most: high-risk input NEVER gets a purely generative response.
 
-Second-person blame. Research shows shame-inducing language activates the threat response, impairing problem-solving — especially for users with depression.
+Crisis signals → real resources (988, 741741, Samaritans, IASP) from a single source-of-truth module. No handler can hardcode a phone number. 90%+ branch coverage on safety paths.
 
-Rewrite: "Page not found. Check the URL, or return to the homepage."
+**5/7**
+Every response carries machine-readable honesty:
 
----
+→ uncertainty: low | medium | high
+→ boundaryNotice: what the skill will never do (diagnose, treat, claim legal compliance)
 
-**Tweet 4:**
-3/ "Fatal error! Contact administrator immediately!"
+Cultural checks default to HIGH uncertainty. Humility as a type system.
 
-Two exclamation points. "Fatal" triggers alarm with no useful information. No timeframe, no next step.
+**6/7**
+Dogfooding moment: I pointed the WCAG auditor at its own landing page.
 
-Rewrite: "System error (500). We've been notified. Try again in 5 minutes or contact support@example.com"
+79/100 at AAA. It found two real CSS bugs (missing line-height, sub-44px touch targets). Fixed, shipped, score improved.
 
----
+Your tool auditing itself > any feature list.
 
-**Tweet 5:**
-4/ "Wrong password."
+**7/7**
+One command to try it:
 
-No recovery path. No format hint. No alternative.
+npx @humanity4ai/mcp-servers
 
-Rewrite: "Password not recognised for this email. Reset your password or try a different email address."
+Works with Claude Code, OpenCode, Copilot, Cursor — any MCP client.
 
----
-
-**Tweet 6:**
-5/ "Application rejected. Better luck next time!"
-
-Dismissive framing. "Luck" implies the outcome was random, not merit-based.
-
-Rewrite: "Application status: Not selected. Other open positions that match your skills are available to view."
-
----
-
-**Tweet 7:**
-6/ "WARNING: Your session expires in 60 seconds! Save now or lose all your changes!"
-
-Threat language. 60-second window. Caps for alarm.
-
-Rewrite: "Your session will expire in 5 minutes due to inactivity. Save your work to continue."
+⭐ if useful: https://github.com/humanity4ai/project_human
 
 ---
 
-**Tweet 8:**
-7/ "No activities logged. You should track your mood daily to see your progress over time."
+## Standalone Posts (spread over launch week)
 
-"Should" = obligation. "Progress" implies current failure.
+**Post A — the consolidation story**
+My 9-skill toolkit: 2 stars.
+My simple WCAG repo: 13 stars.
 
-Rewrite: "When you log activities, they'll appear here. Optional: track your mood to identify patterns."
+Single-purpose repos win GitHub. So I consolidated the content but fragmented the pitch — every skill now has a one-sentence outcome.
 
----
+Full breakdown: [Dev.to article link]
 
-**Tweet 9 (CTA):**
-All 7 rewrites are from the DS-WCS open-source skill — a free cognitive accessibility audit framework for OpenCode.
+**Post B — determinism**
+"Use an LLM to check the LLM" is the industry's answer to AI safety.
 
-15 before/after examples. 40-item checklist. Maps to WCAG 2.2, W3C COGA, ISO 9241-110.
+Mine: 19 crisis-pattern regex libraries, 6 emotion classifiers, 0 tokens.
 
-→ github.com/simonplmak-cloud/depression-sensitive-web-content
+Deterministic > hopeful.
 
-#CognitiveAccessibility #UXWriting #A11y #InclusiveDesign
+https://github.com/humanity4ai/project_human
 
----
+**Post C — WCAG honesty**
+Only 41 of 86 WCAG 2.2 criteria are fully automatable (Deque: ~57% of issues).
 
----
+My auditor scores those and flags the rest manual instead of fake-passing them.
 
-## Thread 2 — "SDG 3 and your error messages"
+Honest tools > confident tools.
 
-**Target audience:** ESG practitioners, responsible tech, product leaders
-**Best posting time:** Monday or Thursday, 8–10am
+**Post D — community question**
+What's the most inhumane thing an AI agent has said to you?
 
----
-
-**Tweet 1 (hook):**
-SDG 3 is about promoting mental health and well-being.
-
-Most product teams think that means building mental health apps.
-
-It also means not writing error messages that shame people.
-
-A thread.
+Collecting real scenarios as test fixtures for the crisis-detection library. 👇
 
 ---
 
-**Tweet 2:**
-280 million people globally live with depression (WHO, 2023).
-
-Depression impairs:
-- Working memory
-- Executive function
-- Processing speed
-- Decision-making
-
-These users are on your platform right now.
-
----
-
-**Tweet 3:**
-When your interface says "You entered invalid data" — it activates the brain's threat response.
-
-For users without depression, that's friction.
-For users with depression, that can be task abandonment.
-
-The cognitive load is not symmetrical.
-
----
-
-**Tweet 4:**
-SDG 3 Target 3.4: "Promote mental health and well-being."
-
-SDG 10 Target 10.3: Eliminate discrimination by disability status.
-
-Cognitive accessibility in digital interfaces is a direct contribution to both.
-
-This is not a stretch. It's the actual standard.
-
----
-
-**Tweet 5:**
-We built an open-source tool that maps content design decisions to these SDG targets — and to WCAG 2.2, W3C COGA, ISO 9241-110, and ISO/IEC 30071-1.
-
-Every finding has a standard citation. Every rewrite has a rationale.
-
-It's a UX tool. Not a clinical one.
-
----
-
-**Tweet 6:**
-It's called DS-WCS — Depression-Sensitive Web Content Support.
-
-Free. Open source. One git clone to install. Works inside OpenCode.
-
-Full SDG & ESG alignment doc included for reporting teams.
-
-→ github.com/simonplmak-cloud/depression-sensitive-web-content
-
-#SDG3 #SDG10 #ESG #ResponsibleTech #CognitiveAccessibility
-
----
-
----
-
-## Thread 3 — "What the S in ESG misses"
-
-**Target audience:** ESG practitioners, CSR teams, sustainability professionals on X
-**Best posting time:** Wednesday, 9–11am
-
----
-
-**Tweet 1 (hook):**
-The S in ESG gets discussed a lot.
-
-Supply chain. Workforce diversity. Community investment.
-
-One thing almost never mentioned: what your digital product does to users with cognitive impairments.
-
-Thread.
-
----
-
-**Tweet 2:**
-Cognitive disabilities — including depression, anxiety, ADHD, and executive function differences — are among the most prevalent disabilities globally.
-
-Depression alone affects 1 in 20 people.
-
-Your digital products are the interface between your organisation and those people.
-
----
-
-**Tweet 3:**
-When that interface uses:
-- Blame language in errors
-- Urgency pressure in CTAs
-- Memory-dependent form instructions
-- Dismissive empty states
-
-...you are systematically excluding a significant user population.
-
-That's a Social pillar issue.
-
----
-
-**Tweet 4:**
-The good news: this is fixable at the content layer.
-
-No engineering sprint. No design system overhaul. Just rewriting the words.
-
-And there are international standards that tell you exactly what to change and why.
-
----
-
-**Tweet 5:**
-WCAG 2.2, W3C COGA, ISO 9241-110, ISO/IEC 30071-1.
-
-These standards cover cognitive accessibility in detail. Most ESG Social disclosures never reference them.
-
-They should.
-
----
-
-**Tweet 6:**
-We built an open-source audit framework that:
-- Flags cognitive accessibility issues in UI content
-- Maps every finding to the relevant standard
-- Provides before/after rewrites
-- Generates ESG-ready documentation
-
-Free. MIT license.
-
-→ github.com/simonplmak-cloud/depression-sensitive-web-content
-
-#ESG #SocialPillar #DEI #Neurodiversity #DigitalEquity #CognitiveAccessibility
-
----
-
----
-
-## Thread 4 — Recap / Best-of (Week 6)
-
-**Target audience:** Broad — followers who missed earlier threads
-**Best posting time:** Friday, 12–2pm
-
----
-
-**Tweet 1 (hook):**
-A month ago I posted about cognitive accessibility in UI content.
-
-Here's what resonated, what I learned, and the tool that started it all.
-
-[Recap thread]
-
----
-
-**Tweet 2:**
-The post that got the most engagement: 7 error messages that silently lose users.
-
-The one that surprised people most: that SDG 3 (mental health) applies directly to how you write form validation.
-
----
-
-**Tweet 3:**
-The most common response I got: "I never thought about error messages as an accessibility issue."
-
-That's exactly the gap DS-WCS addresses.
-
-It's not about screen readers or colour contrast. It's about the emotional and cognitive impact of words.
-
----
-
-**Tweet 4:**
-What DS-WCS actually does:
-
-- Audits UI content for shame/blame language, urgency pressure, and cognitive load
-- Maps findings to WCAG 2.2, W3C COGA, ISO 9241-110, ISO/IEC 30071-1
-- Provides 15 before/after rewrites
-- Generates ESG-ready audit documentation
-
-Free. Open source. Works in OpenCode.
-
----
-
-**Tweet 5:**
-If you're a UX writer, content designer, or accessibility practitioner — fork it, use it, add examples.
-
-If you're on an ESG or CSR team — the SDG & ESG alignment doc is ready to drop into a disclosure.
-
-→ github.com/simonplmak-cloud/depression-sensitive-web-content
-
-#CognitiveAccessibility #ESG #SDG #UXWriting #A11y #OpenSource #InclusiveDesign
+## Hashtags & Handles
+
+- Primary: #BuildInPublic #OpenSource #AIAgents #MCP #a11y
+- Tag when relevant: @github (for MCP-related posts), accessibility community accounts
+- Never hashtag the words "mental health" on launch posts — attracts the wrong algorithmic context; let the content carry it

--- a/site/index.html
+++ b/site/index.html
@@ -168,14 +168,16 @@
     </main>
 
     <footer class="site-footer" role="contentinfo">
-      <p>
-        ⭐ <a href="https://github.com/humanity4ai/project_human">Star on GitHub</a> ·
-        <a href="https://twitter.com/intent/tweet?text=Humanity4AI%20%E2%80%94%209%20humanity%20skills%20for%20AI%20agents%20%F0%9F%A4%9D%0A%0ACrisis%20detection%2C%20WCAG%20audits%2C%20empathy%2C%20cultural%20sensitivity%2C%20and%20more.%0A%0Ahttps%3A%2F%2Fgithub.com%2Fhumanity4ai%2Fproject_human">Share on X</a> ·
-        MIT License · Copyright © 2026 Ascent Partners Foundation ·
-        <a href="https://github.com/humanity4ai/project_human" rel="noopener noreferrer">GitHub</a> ·
-        <a href="https://github.com/humanity4ai/project_human/blob/main/docs/GOVERNANCE.md" rel="noopener noreferrer">Governance</a> ·
-        <a href="https://github.com/humanity4ai/project_human/blob/main/SECURITY.md" rel="noopener noreferrer">Security</a>
-      </p>
+      <nav aria-label="Footer">
+        <p>
+          ⭐ <a href="https://github.com/humanity4ai/project_human">Star on GitHub</a> ·
+          <a href="https://twitter.com/intent/tweet?text=Humanity4AI%20%E2%80%94%209%20humanity%20skills%20for%20AI%20agents%20%F0%9F%A4%9D%0A%0ACrisis%20detection%2C%20WCAG%20audits%2C%20empathy%2C%20cultural%20sensitivity%2C%20and%20more.%0A%0Ahttps%3A%2F%2Fgithub.com%2Fhumanity4ai%2Fproject_human">Share on X</a> ·
+          MIT License · Copyright © 2026 Ascent Partners Foundation ·
+          <a href="https://github.com/humanity4ai/project_human" rel="noopener noreferrer">GitHub</a> ·
+          <a href="https://github.com/humanity4ai/project_human/blob/main/docs/GOVERNANCE.md" rel="noopener noreferrer">Governance</a> ·
+          <a href="https://github.com/humanity4ai/project_human/blob/main/SECURITY.md" rel="noopener noreferrer">Security</a>
+        </p>
+      </nav>
     </footer>
   </body>
 </html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -18,6 +18,7 @@ body {
   font-family: "IBM Plex Sans", "Segoe UI", "Helvetica Neue", sans-serif;
   color: var(--text);
   background: var(--bg);
+  line-height: 1.6;
 }
 
 @media (prefers-reduced-motion: no-preference) {
@@ -131,6 +132,11 @@ h1 {
 }
 
 .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  min-width: 44px;
   border: 1px solid var(--line);
   padding: 0.6rem 0.9rem;
   border-radius: 999px;


### PR DESCRIPTION
## Summary

Rewrites the salvaged marketing packs (originally written for the archived depression-sensitive-web-content repo) into ready-to-publish Humanity4AI launch assets, adds the 48-hour coordinated launch plan, and fixes three genuine accessibility issues on the landing site found by dogfooding the repo's own WCAG 2.2 auditor (self-score was 79/100 at AAA).

## Contribution Type

- [ ] New skill
- [ ] Scenario addition to existing skill
- [ ] Bug fix (eval harness, MCP server, schemas)
- [ ] MCP action addition or update
- [x] Documentation
- [ ] Integration adapter
- [x] Other: site accessibility fixes (CSS/HTML)

## Impact Area

- [ ] `skills/`
- [ ] `mcp-servers/`
- [ ] `evals/`
- [x] `docs/` — docs/marketing/ (5 rewritten packs + launch-plan.md)
- [ ] `.github/`
- [x] `site/` — line-height, 44px targets, footer nav landmark

## Test Evidence

No TypeScript/schemas/handlers/eval fixtures changed — markdown + static site only. CI runs on this PR.

## Safety Checklist

- [x] No clinical diagnosis, treatment plans, or medical advice content (marketing copy explicitly states non-clinical positioning)
- [x] No legal advice content
- [x] Safety boundaries are explicit in all modified `skill.yaml` files — none modified
- [x] Safety-critical skills include escalation language in boundaries — unchanged
- [x] Crisis-adjacent content routes to professional resources — marketing copy reinforces this

## Quality Checklist

- [ ] `pnpm check` / `pnpm evals` / `pnpm test` — CI
- [x] CHANGELOG.md updated — N/A for marketing docs (covered under Unreleased discoverability section from #171)
- [x] Provenance/license — all original content

## Self-Certification

- No content that could be mistaken for clinical, medical, or legal advice
- I have read CONTRIBUTING.md and SECURITY.md
- Content is original (rewritten from prior same-owner materials)