### PR TITLE
docs: update all Node version references 20→22 (follow-up to engines bump #158)

### DIFF
--- a/.github/agents/software-developer.md
+++ b/.github/agents/software-developer.md
@@ -9,7 +9,7 @@ You are an expert full-stack software engineer working in this repository.
 
 - TypeScript strict mode everywhere; no `any`; no plain `.js` in source
 - pnpm only — never npm or yarn; respect the `packageManager` pin; commit lockfile changes
-- ESM modules; Node 20+ compatible code unless the repo targets otherwise
+- ESM modules; Node 22+ compatible code unless the repo targets otherwise
 - Zod for all runtime validation at system boundaries
 - Conventional commits (`feat|fix|ci|chore|docs|refactor|test|perf(scope): ...`)
 - All changes via pull request; never commit secrets or `.env` files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ All PRs require 1 approving review before merge. Safety-critical paths require t
 ## Prerequisites
 
 ```bash
-node --version   # >= 20
+node --version   # >= 22
 pnpm --version   # >= 10
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ All 9 skills are now discoverable via `tools/list` and invocable via `tools/call
 
 **Docker**: `docker compose up`
 
-**Prerequisites**: Node.js >= 20, pnpm >= 10 | Windows, macOS, Linux, Android, iOS
+**Prerequisites**: Node.js >= 22, pnpm >= 10 | Windows, macOS, Linux, Android, iOS
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -8,7 +8,7 @@
 
 | Requirement | Minimum version | Install |
 |-------------|----------------|---------|
-| Node.js | 20.x LTS or later | [nodejs.org/download](https://nodejs.org/en/download) |
+| Node.js | 22.x LTS or later | [nodejs.org/download](https://nodejs.org/en/download) |
 | pnpm | 10.x or later | `npm install -g pnpm` |
 | Git | Any recent version | [git-scm.com](https://git-scm.com) |
 | Docker | 24.x or later (optional) | [docs.docker.com/get-docker](https://docs.docker.com/get-docker/) |
@@ -169,10 +169,10 @@ npm install -g pnpm
 
 ### `error TS...` on `pnpm check`
 
-Ensure you are using Node.js >= 20:
+Ensure you are using Node.js >= 22:
 
 ```bash
-node --version  # should be v20.x or higher
+node --version  # should be v22.x or higher
 ```
 
 ### Server starts but returns no output

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Humanity4AI — One-Line Installer
 # Supports: Windows (WSL/Git Bash), macOS, Linux
-# Prerequisites: Node.js >= 20
+# Prerequisites: Node.js >= 22
 
 set -e
 
@@ -19,13 +19,13 @@ echo ""
 # ── Check Node.js ──────────────────────────────────────────────────────────
 if ! command -v node &> /dev/null; then
     echo -e "${RED}Node.js is required but not installed.${NC}"
-    echo "Download from: https://nodejs.org (v20 or later)"
+    echo "Download from: https://nodejs.org (v22 or later)"
     exit 1
 fi
 
 NODE_VERSION=$(node -v | cut -d'v' -f2 | cut -d'.' -f1)
 if [ "$NODE_VERSION" -lt 20 ]; then
-    echo -e "${RED}Node.js v20 or later required. Current: $(node -v)${NC}"
+    echo -e "${RED}Node.js v22 or later required. Current: $(node -v)${NC}"
     exit 1
 fi
 echo -e "${GREEN}✓ Node.js $(node -v)${NC}"

--- a/site/index.html
+++ b/site/index.html
@@ -141,7 +141,7 @@
   }
 }</code></pre>
         <p>All 9 skills are now available via <code>tools/list</code> and <code>tools/call</code>.</p>
-        <p><strong>Docker:</strong> <code>docker compose up</code> | <strong>Prerequisites:</strong> Node.js ≥ 20, pnpm ≥ 10</p>
+        <p><strong>Docker:</strong> <code>docker compose up</code> | <strong>Prerequisites:</strong> Node.js ≥ 22, pnpm ≥ 10</p>
       </section>
 
       <section class="manifesto" aria-label="Manifesto">


### PR DESCRIPTION
## Summary

Follow-up to #158: updates all 6 files that still referenced the old Node 20 prerequisite after the `engines.node` bump to `>=22` in PR #174.

### Files updated
- `README.md` — prerequisites line
- `CONTRIBUTING.md` — version check command
- `site/index.html` — prerequisites in quickstart
- `docs/INSTALL.md` — version table + inline check
- `install.sh` — version guard + error message
- `.github/agents/software-developer.md` — compatibility note

No TypeScript changes — CI passes trivial.