### PR TITLE
docs: fix 15+ stale references across all documentation (audit cleanup)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -54,7 +54,7 @@ $ pnpm test
 ## Quality Checklist
 
 - [ ] `pnpm check` passes (TypeScript)
-- [ ] `pnpm evals` passes (all 11 gates)
+- [ ] `pnpm evals` passes (all 10 gates)
 - [ ] `pnpm test` passes (all tests)
 - [ ] If manifesto-related, linked principle in `docs/manifesto-roadmap-map.md` and linked issue are included
 - [ ] New skills have at least 10 scenarios

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
 repository-code: "https://github.com/humanity4ai/project_human"
 url: "https://humanity4ai.github.io/project_human/"
 abstract: >
-  Open skill system for humane AI behaviour — 10 reusable specifications
+  Open skill system for humane AI behaviour — 9 reusable specifications
   covering accessibility, emotional safety, inclusive design, and communication
   patterns, with MCP contracts and automated evaluation gates.
 keywords:
@@ -21,5 +21,5 @@ keywords:
   - skills
   - human-centered AI
 license: MIT
-version: 0.2.0
-date-released: "2026-03-01"
+version: 1.0.4
+date-released: "2026-07-24"

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -34,18 +34,18 @@ pnpm install
 
 ```bash
 pnpm check   # TypeScript type checks
-pnpm evals   # Skill quality gates (all 11 should pass)
+pnpm evals   # Skill quality gates (all 10 should pass)
 ```
 
 Expected output:
 
 ```
-PASS  wcag-aaa-accessibility
+PASS  accessibility
 PASS  depression-sensitive-content
 ...
 PASS  contract-consistency
 
-All 11 checks passed.
+All 10 checks passed.
 ```
 
 ### 4. Start the MCP server
@@ -57,8 +57,8 @@ pnpm start
 The server will print a startup banner to stderr:
 
 ```
-Humanity4AI MCP Server v1.0.0
-Actions: 11 registered
+Humanity4AI MCP Server v1.0.4
+Actions: 9 registered
 Transport: stdio (MCP JSON-RPC 2.0)
 Ready
 ```
@@ -72,7 +72,7 @@ echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
   | pnpm --filter @humanity4ai/mcp-servers exec tsx src/mcp-server.ts
 ```
 
-You should receive a JSON response listing all 11 registered actions.
+You should receive a JSON response listing all 9 registered actions.
 
 ### 6. Invoke a skill
 
@@ -199,7 +199,7 @@ Run this checklist before deploying to any environment:
 pnpm install           # Dependencies installed
 pnpm check             # TypeScript passes
 pnpm build             # Package builds cleanly
-pnpm evals             # All 11 quality gates pass
+pnpm evals             # All 10 quality gates pass
 echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | pnpm --filter @humanity4ai/mcp-servers exec tsx src/mcp-server.ts
-# Should return JSON with 11 actions
+# Should return JSON with 9 actions
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,9 +65,7 @@ Each skill is defined by a `SKILL.md` file containing its purpose, boundaries, p
 | Empathetic Communication | `communication` | [SKILL.md](../skills/empathetic-communication/SKILL.md) |
 | Supportive Conversation (incl. grief) | `emotional-safety` | [SKILL.md](../skills/supportive-conversation/SKILL.md) |
 | Neurodiversity-Aware Design | `neurodiversity` | [SKILL.md](../skills/neurodiversity-aware-design/SKILL.md) |
-| Supportive Conversation | `communication` | [SKILL.md](../skills/supportive-conversation/SKILL.md) |
-| WCAG AAA Accessibility | `accessibility` | [SKILL.md](../skills/wcag-aaa-accessibility/SKILL.md) |
-| WCAG AA Accessibility | `accessibility` | [SKILL.md](../skills/wcag-aa-accessibility/SKILL.md) |
+| Accessibility (WCAG A/AA/AAA) | `accessibility` | [SKILL.md](../skills/accessibility/SKILL.md) |
 
 The full structured index of all skills is available at [`skills/index.yaml`](../skills/index.yaml).
 

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -5,7 +5,7 @@
 | Directory | Purpose |
 |-----------|---------|
 | `knowledge-core/` | Canonical principles, taxonomy, and uncertainty schema |
-| `skills/` | 10 launch skill packs |
+| `skills/` | 9 launch skill packs |
 | `mcp-servers/` | MCP action contracts, JSON schemas, and runtime server |
 | `evals/` | Baseline evaluation harness |
 | `templates/` | Contributor skill template |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,14 +4,16 @@
 
 - 9 launch skills with structured artifacts
 - MCP action contracts and schema set
-- Standard MCP SDK (JSON-RPC 2.0) implementation
+- Standard MCP SDK (JSON-RPC 2.0) stdio + Streamable HTTP transport
+- Vercel serverless deployment (api/mcp.ts)
 - Baseline evaluation harness and governance framework
+- 10 automated quality gates
 
 ## v1.1 (Next)
 
 - Platform adapters for OpenCode, Claude Code, and Copilot (MCP SDK server)
-- 11 automated quality gates
-- HTTP/SSE transport for remote MCP server deployments
+- Published MCP Registry listing (mcp-publisher)
+- Rich scenario scoring beyond structural checks
 
 ## v2.0 (Future)
 

--- a/docs/SYSTEM_PROMPT.md
+++ b/docs/SYSTEM_PROMPT.md
@@ -41,16 +41,14 @@ The following are the most important files for LLM context. You can fetch any of
 | `llms-full.txt` | Single-file full context for LLMs | https://raw.githubusercontent.com/humanity4ai/project_human/main/llms-full.txt |
 | `knowledge-core/principles.md` | The five core principles | https://raw.githubusercontent.com/humanity4ai/project_human/main/knowledge-core/principles.md |
 | `skills/age-inclusive-design/SKILL.md` | Age-inclusive design skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/age-inclusive-design/SKILL.md |
+| `skills/accessibility/SKILL.md` | WCAG accessibility audit skill (A/AA/AAA) | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/accessibility/SKILL.md |
 | `skills/cognitive-accessibility/SKILL.md` | Cognitive accessibility skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/cognitive-accessibility/SKILL.md |
 | `skills/conflict-de-escalation/SKILL.md` | Conflict de-escalation skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/conflict-de-escalation/SKILL.md |
 | `skills/cultural-sensitivity/SKILL.md` | Cultural sensitivity skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/cultural-sensitivity/SKILL.md |
 | `skills/depression-sensitive-content/SKILL.md` | Depression-sensitive content skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/depression-sensitive-content/SKILL.md |
 | `skills/empathetic-communication/SKILL.md` | Empathetic communication skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/empathetic-communication/SKILL.md |
-| `skills/supportive-conversation/SKILL.md` | Supportive conversation (incl. grief) skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/supportive-conversation/SKILL.md |
 | `skills/neurodiversity-aware-design/SKILL.md` | Neurodiversity-aware design skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/neurodiversity-aware-design/SKILL.md |
 | `skills/supportive-conversation/SKILL.md` | Supportive conversation skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/supportive-conversation/SKILL.md |
-| `skills/wcag-aaa-accessibility/SKILL.md` | WCAG AAA accessibility skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/wcag-aaa-accessibility/SKILL.md |
-| `skills/wcag-aa-accessibility/SKILL.md` | WCAG AA accessibility skill | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/wcag-aa-accessibility/SKILL.md |
 
 ## Interaction Style
 

--- a/docs/good-first-issues.md
+++ b/docs/good-first-issues.md
@@ -19,7 +19,7 @@ Add at least 10 multilingual prompts to `skills/supportive-conversation/scenario
 
 ### #3 — Quality uplift for launch skills
 
-Review boundary wording, `SKILL.md` anti-patterns, and rubric examples for 4 skills: `wcag-aaa-accessibility`, `depression-sensitive-content`, `supportive-conversation`, `cognitive-accessibility`.
+Review boundary wording, `SKILL.md` anti-patterns, and rubric examples for 4 skills: `accessibility`, `depression-sensitive-content`, `supportive-conversation`, `cognitive-accessibility`.
 
 - Issue: https://github.com/humanity4ai/project_human/issues/3
 - Labels: `help wanted`

--- a/docs/manifesto-coverage-map.md
+++ b/docs/manifesto-coverage-map.md
@@ -10,7 +10,7 @@ Each of the 5 Humanity4AI core principles mapped to implementation artifacts.
 |--------------|------|----------|
 | Skill | `skills/cultural-sensitivity/SKILL.md` | Notes Hofstede contested, cultural variation |
 | Skill | `skills/conflict-de-escalation/SKILL.md` | Intensity-based adaptation |
-| Skill | `skills/wcag-aa-accessibility/SKILL.md` | Heuristic mode for ambiguous input |
+| Skill | `skills/accessibility/SKILL.md` | Heuristic mode for ambiguous input |
 | Handler | `handlers.ts` → `handleCulturalContext` | uncertainty: "high" — acknowledges cultural generalization limits |
 | Handler | `handlers.ts` → `handleWcagAaCheck` | heuristic flag for non-HTML input |
 | Test | `handlers.test.ts` H-35..H-44 | Cultural context variations |
@@ -82,4 +82,4 @@ Each of the 5 Humanity4AI core principles mapped to implementation artifacts.
 **No uncovered principles. All 5 principles have at least 7 traceable artifacts across code, tests, docs, and CI.**
 
 ---
-Generated: 2026-05-26 | v1.0.0
+Generated: 2026-07-24 | v1.0.4

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -29,7 +29,7 @@ Before calling any tools, clients must send an `initialize` request:
 Response:
 
 ```json
-{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"humanity4ai-mcp","version":"1.0.0"}}}
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"humanity4ai-mcp",  "version":"1.0.4"}}}
 ```
 
 ---
@@ -40,7 +40,7 @@ Response:
 {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
 ```
 
-Response includes all 11 registered tools with their name, description, and input schema.
+Response includes all 9 registered tools with their name, description, and input schema.
 
 ---
 

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -2,7 +2,7 @@
 
 The evaluation harness runs **10 automated checks** — one for each of the 9 skills plus contract consistency.
 
-## Gates 1-10: Skill Completeness (per skill)
+## Gates 1–9: Skill Completeness (per skill)
 
 For each skill in `skills/`:
 
@@ -57,8 +57,7 @@ PASS  empathetic-communication
 PASS  supportive-conversation
 PASS  neurodiversity-aware-design
 PASS  supportive-conversation
-PASS  wcag-aaa-accessibility
-PASS  wcag-aa-accessibility
+PASS  accessibility
 PASS  contract-consistency
 
 All 9 checks passed.

--- a/docs/traction-14-day.md
+++ b/docs/traction-14-day.md
@@ -5,7 +5,7 @@ This plan is designed to convert visitors into contributors and integrators.
 ## Week 1
 
 - Day 1: Launch post with value proposition and quickstart.
-- Day 2: Skill spotlight 1 (`wcag-aaa-accessibility`) with before/after example.
+- Day 2: Skill spotlight 1 (`accessibility`) with before/after example.
 - Day 3: Integration spotlight (`supportive_reply` MCP invocation snippet).
 - Day 4: Contributor call with one starter issue.
 - Day 5: Skill spotlight 2 (`depression-sensitive-content`) with boundaries note.

--- a/docs/worked-example.md
+++ b/docs/worked-example.md
@@ -29,7 +29,7 @@ pnpm start
 You will see on stderr:
 
 ```
-Humanity4AI MCP Server v1.0.0 (JSON-RPC 2.0)
+Humanity4AI MCP Server v1.0.4 (JSON-RPC 2.0)
 Tools: 9 registered
 Transport: stdio (MCP SDK)
 Ready — waiting for MCP client connections

--- a/evals/README.md
+++ b/evals/README.md
@@ -58,10 +58,10 @@ PASS  empathetic-communication
 PASS  supportive-conversation
 PASS  neurodiversity-aware-design
 PASS  supportive-conversation
-PASS  wcag-aaa-accessibility
+PASS  accessibility
 PASS  contract-consistency
 
-All 11 checks passed.
+All 10 checks passed.
 ```
 
 ---

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ NC='\033[0m'
 
 echo -e "${CYAN}╔══════════════════════════════════════════╗${NC}"
 echo -e "${CYAN}║     Humanity4AI — One-Line Installer    ║${NC}"
-echo -e "${CYAN}║         v1.0.0 — 11 Humanity Skills     ║${NC}"
+echo -e "${CYAN}║         v1.0.4 — 9 Humanity Skills      ║${NC}"
 echo -e "${CYAN}╚══════════════════════════════════════════╝${NC}"
 echo ""
 
@@ -24,7 +24,7 @@ if ! command -v node &> /dev/null; then
 fi
 
 NODE_VERSION=$(node -v | cut -d'v' -f2 | cut -d'.' -f1)
-if [ "$NODE_VERSION" -lt 20 ]; then
+    if [ "$NODE_VERSION" -lt 22 ]; then
     echo -e "${RED}Node.js v22 or later required. Current: $(node -v)${NC}"
     exit 1
 fi

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -10,17 +10,17 @@ All links in this file use absolute raw.githubusercontent.com URLs pointing to t
 ---
 ## System Prompt
 
-See: https://raw.githubusercontent.com/humanity4ai/project_human/development/SYSTEM_PROMPT.md
+See: https://raw.githubusercontent.com/humanity4ai/project_human/main/SYSTEM_PROMPT.md
 
 ---
 ## Core Principles
 
-See: https://raw.githubusercontent.com/humanity4ai/project_human/development/knowledge-core/principles.md
+See: https://raw.githubusercontent.com/humanity4ai/project_human/main/knowledge-core/principles.md
 
 ---
 ## Taxonomy
 
-See: https://raw.githubusercontent.com/humanity4ai/project_human/development/knowledge-core/taxonomy.md
+See: https://raw.githubusercontent.com/humanity4ai/project_human/main/knowledge-core/taxonomy.md
 
 ---
 ## Skill Reference
@@ -3006,5 +3006,5 @@ If unable to complete the audit:
 ---
 ## MCP Tool Signatures
 
-See: https://raw.githubusercontent.com/humanity4ai/project_human/development/llms.txt
-See: https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/README.md
+See: https://raw.githubusercontent.com/humanity4ai/project_human/main/llms.txt
+See: https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/README.md

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 This file guides Large Language Models (LLMs) on how to understand and use the
 `humanity4ai/project_human` repository. For a single-file version with all
-content, see https://raw.githubusercontent.com/humanity4ai/project_human/development/llms-full.txt
+content, see https://raw.githubusercontent.com/humanity4ai/project_human/main/llms-full.txt
 
 ---
 
@@ -10,11 +10,11 @@ content, see https://raw.githubusercontent.com/humanity4ai/project_human/develop
 
 Start here to understand the project's foundational values.
 
-- **Core Principles**: https://raw.githubusercontent.com/humanity4ai/project_human/development/knowledge-core/principles.md
+- **Core Principles**: https://raw.githubusercontent.com/humanity4ai/project_human/main/knowledge-core/principles.md
   — The five core principles of the Humanity4AI project.
-- **Taxonomy**: https://raw.githubusercontent.com/humanity4ai/project_human/development/knowledge-core/taxonomy.md
+- **Taxonomy**: https://raw.githubusercontent.com/humanity4ai/project_human/main/knowledge-core/taxonomy.md
   — The 10 launch categories for skills and their scope.
-- **System Prompt**: https://raw.githubusercontent.com/humanity4ai/project_human/development/SYSTEM_PROMPT.md
+- **System Prompt**: https://raw.githubusercontent.com/humanity4ai/project_human/main/SYSTEM_PROMPT.md
   — The canonical system prompt for LLMs using the Humanity4AI skillset.
 
 ---
@@ -24,17 +24,17 @@ Start here to understand the project's foundational values.
 This project provides 9 skills via a standard MCP (Model Context Protocol)
 server. The server is published to npm and can be run with `npx`.
 
-- **Quick Start**: https://raw.githubusercontent.com/humanity4ai/project_human/development/README.md
+- **Quick Start**: https://raw.githubusercontent.com/humanity4ai/project_human/main/README.md
   — How to start the MCP server (see section: MCP Runtime v0.1).
-- **Tool Reference**: https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/README.md
+- **Tool Reference**: https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/README.md
   — Full reference for all 9 tools, including input/output schemas.
-- **Agent Adapter Guide**: https://raw.githubusercontent.com/humanity4ai/project_human/development/docs/agent-adapters.md
+- **Agent Adapter Guide**: https://raw.githubusercontent.com/humanity4ai/project_human/main/docs/agent-adapters.md
   — Integration examples for OpenCode, Claude, Cursor, Copilot, Manus AI, n8n, and LangChain.
-- **Action Contracts**: https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/src/index.ts
+- **Action Contracts**: https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/src/index.ts
   — TypeScript source for all 9 action contracts.
-- **MCP Server Source**: https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/src/mcp-server.ts
+- **MCP Server Source**: https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/src/mcp-server.ts
   — Full MCP server implementation with tool registrations.
-- **Handler Source**: https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/src/handlers.ts
+- **Handler Source**: https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/src/handlers.ts
   — All 9 action handler implementations.
 
 ### Tool Signatures
@@ -58,7 +58,7 @@ server. The server is published to npm and can be run with `npx`.
 If you do not have tool-use capabilities, you can use the skills via prompt
 engineering.
 
-- **Prompting Guide**: https://raw.githubusercontent.com/humanity4ai/project_human/development/README.md
+- **Prompting Guide**: https://raw.githubusercontent.com/humanity4ai/project_human/main/README.md
   — How to load skill content into your context window (see section: Alternative — Prompt Engineering).
 
 ---
@@ -68,44 +68,44 @@ engineering.
 This is the full list of all 9 skills. Each `SKILL.md` contains the full
 specification, including purpose, boundaries, and principles.
 
-- **Skill Index**: https://raw.githubusercontent.com/humanity4ai/project_human/development/skills/index.yaml
+- **Skill Index**: https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/index.yaml
   — A structured YAML index of all available skills.
 
 | Skill | Category | SKILL.md URL |
 |---|---|---|
-| `age-inclusive-design` | `age-inclusion` | https://raw.githubusercontent.com/humanity4ai/project_human/development/skills/age-inclusive-design/SKILL.md |
-| `cognitive-accessibility` | `cognitive-support` | https://raw.githubusercontent.com/humanity4ai/project_human/development/skills/cognitive-accessibility/SKILL.md |
-| `conflict-de-escalation` | `conflict-navigation` | https://raw.githubusercontent.com/humanity4ai/project_human/development/skills/conflict-de-escalation/SKILL.md |
-| `cultural-sensitivity` | `cultural-context` | https://raw.githubusercontent.com/humanity4ai/project_human/development/skills/cultural-sensitivity/SKILL.md |
-| `depression-sensitive-content` | `emotional-safety` | https://raw.githubusercontent.com/humanity4ai/project_human/development/skills/depression-sensitive-content/SKILL.md |
-| `empathetic-communication` | `communication` | https://raw.githubusercontent.com/humanity4ai/project_human/development/skills/empathetic-communication/SKILL.md |
-| `supportive-conversation` | `emotional-safety` | https://raw.githubusercontent.com/humanity4ai/project_human/development/skills/supportive-conversation/SKILL.md |
-| `neurodiversity-aware-design` | `neurodiversity` | https://raw.githubusercontent.com/humanity4ai/project_human/development/skills/neurodiversity-aware-design/SKILL.md |
-| `accessibility` | `accessibility` | https://raw.githubusercontent.com/humanity4ai/project_human/development/skills/accessibility/SKILL.md |
+| `age-inclusive-design` | `age-inclusion` | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/age-inclusive-design/SKILL.md |
+| `cognitive-accessibility` | `cognitive-support` | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/cognitive-accessibility/SKILL.md |
+| `conflict-de-escalation` | `conflict-navigation` | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/conflict-de-escalation/SKILL.md |
+| `cultural-sensitivity` | `cultural-context` | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/cultural-sensitivity/SKILL.md |
+| `depression-sensitive-content` | `emotional-safety` | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/depression-sensitive-content/SKILL.md |
+| `empathetic-communication` | `communication` | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/empathetic-communication/SKILL.md |
+| `supportive-conversation` | `emotional-safety` | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/supportive-conversation/SKILL.md |
+| `neurodiversity-aware-design` | `neurodiversity` | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/neurodiversity-aware-design/SKILL.md |
+| `accessibility` | `accessibility` | https://raw.githubusercontent.com/humanity4ai/project_human/main/skills/accessibility/SKILL.md |
 
 ---
 
 ## 5. Knowledge Core
 
-- **Principles**: https://raw.githubusercontent.com/humanity4ai/project_human/development/knowledge-core/principles.md
-- **Taxonomy**: https://raw.githubusercontent.com/humanity4ai/project_human/development/knowledge-core/taxonomy.md
-- **Uncertainty Schema**: https://raw.githubusercontent.com/humanity4ai/project_human/development/knowledge-core/uncertainty-schema.md
+- **Principles**: https://raw.githubusercontent.com/humanity4ai/project_human/main/knowledge-core/principles.md
+- **Taxonomy**: https://raw.githubusercontent.com/humanity4ai/project_human/main/knowledge-core/taxonomy.md
+- **Uncertainty Schema**: https://raw.githubusercontent.com/humanity4ai/project_human/main/knowledge-core/uncertainty-schema.md
 
 ---
 
 ## 6. Governance & Contribution
 
-- **How to Contribute**: https://raw.githubusercontent.com/humanity4ai/project_human/development/CONTRIBUTING.md
-- **Good First Issues**: https://raw.githubusercontent.com/humanity4ai/project_human/development/docs/good-first-issues.md
-- **Governance**: https://raw.githubusercontent.com/humanity4ai/project_human/development/GOVERNANCE.md
-- **Code of Conduct**: https://raw.githubusercontent.com/humanity4ai/project_human/development/CODE_OF_CONDUCT.md
-- **Security Policy**: https://raw.githubusercontent.com/humanity4ai/project_human/development/SECURITY.md
-- **Maintainers**: https://raw.githubusercontent.com/humanity4ai/project_human/development/MAINTAINERS.md
-- **Release Notes**: https://raw.githubusercontent.com/humanity4ai/project_human/development/RELEASE_NOTES.md
-- **Roadmap**: https://raw.githubusercontent.com/humanity4ai/project_human/development/ROADMAP.md
-- **Repository Map**: https://raw.githubusercontent.com/humanity4ai/project_human/development/REPO_MAP.md
-- **Install Guide**: https://raw.githubusercontent.com/humanity4ai/project_human/development/INSTALL.md
-- **Operations Guide**: https://raw.githubusercontent.com/humanity4ai/project_human/development/OPERATIONS.md
+- **How to Contribute**: https://raw.githubusercontent.com/humanity4ai/project_human/main/CONTRIBUTING.md
+- **Good First Issues**: https://raw.githubusercontent.com/humanity4ai/project_human/main/docs/good-first-issues.md
+- **Governance**: https://raw.githubusercontent.com/humanity4ai/project_human/main/GOVERNANCE.md
+- **Code of Conduct**: https://raw.githubusercontent.com/humanity4ai/project_human/main/CODE_OF_CONDUCT.md
+- **Security Policy**: https://raw.githubusercontent.com/humanity4ai/project_human/main/SECURITY.md
+- **Maintainers**: https://raw.githubusercontent.com/humanity4ai/project_human/main/MAINTAINERS.md
+- **Release Notes**: https://raw.githubusercontent.com/humanity4ai/project_human/main/RELEASE_NOTES.md
+- **Roadmap**: https://raw.githubusercontent.com/humanity4ai/project_human/main/ROADMAP.md
+- **Repository Map**: https://raw.githubusercontent.com/humanity4ai/project_human/main/REPO_MAP.md
+- **Install Guide**: https://raw.githubusercontent.com/humanity4ai/project_human/main/INSTALL.md
+- **Operations Guide**: https://raw.githubusercontent.com/humanity4ai/project_human/main/OPERATIONS.md
 
 ---
 
@@ -115,34 +115,34 @@ All JSON input/output schemas for the 9 actions are available at:
 
 | Schema | URL |
 |---|---|
-| `accessibility.input.json` | https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/schemas/accessibility.input.json |
-| `accessibility.output.json` | https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/schemas/accessibility.output.json |
-| `depression-sensitive-content.input.json` | https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/schemas/depression-sensitive-content.input.json |
-| `depression-sensitive-content.output.json` | https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/schemas/depression-sensitive-content.output.json |
-| `supportive-conversation.input.json` | https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/schemas/supportive-conversation.input.json |
-| `supportive-conversation.output.json` | https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/schemas/supportive-conversation.output.json |
-| `cognitive-accessibility.input.json` | https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/schemas/cognitive-accessibility.input.json |
-| `cognitive-accessibility.output.json` | https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/schemas/cognitive-accessibility.output.json |
-| `cultural-sensitivity.input.json` | https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/schemas/cultural-sensitivity.input.json |
-| `cultural-sensitivity.output.json` | https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/schemas/cultural-sensitivity.output.json |
-| `conflict-de-escalation.input.json` | https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/schemas/conflict-de-escalation.input.json |
-| `conflict-de-escalation.output.json` | https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/schemas/conflict-de-escalation.output.json |
-| `empathetic-communication.input.json` | https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/schemas/empathetic-communication.input.json |
-| `empathetic-communication.output.json` | https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/schemas/empathetic-communication.output.json |
-| `neurodiversity-aware-design.input.json` | https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/schemas/neurodiversity-aware-design.input.json |
-| `neurodiversity-aware-design.output.json` | https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/schemas/neurodiversity-aware-design.output.json |
-| `age-inclusive-design.input.json` | https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/schemas/age-inclusive-design.input.json |
-| `age-inclusive-design.output.json` | https://raw.githubusercontent.com/humanity4ai/project_human/development/mcp-servers/schemas/age-inclusive-design.output.json |
+| `accessibility.input.json` | https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/schemas/accessibility.input.json |
+| `accessibility.output.json` | https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/schemas/accessibility.output.json |
+| `depression-sensitive-content.input.json` | https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/schemas/depression-sensitive-content.input.json |
+| `depression-sensitive-content.output.json` | https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/schemas/depression-sensitive-content.output.json |
+| `supportive-conversation.input.json` | https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/schemas/supportive-conversation.input.json |
+| `supportive-conversation.output.json` | https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/schemas/supportive-conversation.output.json |
+| `cognitive-accessibility.input.json` | https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/schemas/cognitive-accessibility.input.json |
+| `cognitive-accessibility.output.json` | https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/schemas/cognitive-accessibility.output.json |
+| `cultural-sensitivity.input.json` | https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/schemas/cultural-sensitivity.input.json |
+| `cultural-sensitivity.output.json` | https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/schemas/cultural-sensitivity.output.json |
+| `conflict-de-escalation.input.json` | https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/schemas/conflict-de-escalation.input.json |
+| `conflict-de-escalation.output.json` | https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/schemas/conflict-de-escalation.output.json |
+| `empathetic-communication.input.json` | https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/schemas/empathetic-communication.input.json |
+| `empathetic-communication.output.json` | https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/schemas/empathetic-communication.output.json |
+| `neurodiversity-aware-design.input.json` | https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/schemas/neurodiversity-aware-design.input.json |
+| `neurodiversity-aware-design.output.json` | https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/schemas/neurodiversity-aware-design.output.json |
+| `age-inclusive-design.input.json` | https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/schemas/age-inclusive-design.input.json |
+| `age-inclusive-design.output.json` | https://raw.githubusercontent.com/humanity4ai/project_human/main/mcp-servers/schemas/age-inclusive-design.output.json |
 
 ---
 
 ## 8. Documentation
 
-- **Documentation Index**: https://raw.githubusercontent.com/humanity4ai/project_human/development/docs/README.md
-- **Protocol Specification**: https://raw.githubusercontent.com/humanity4ai/project_human/development/docs/protocol.md
-- **Agent Adapter Guide**: https://raw.githubusercontent.com/humanity4ai/project_human/development/docs/agent-adapters.md
-- **Quality Gates**: https://raw.githubusercontent.com/humanity4ai/project_human/development/docs/quality-gates.md
-- **Worked Example**: https://raw.githubusercontent.com/humanity4ai/project_human/development/docs/worked-example.md
-- **Manifesto**: https://raw.githubusercontent.com/humanity4ai/project_human/development/docs/manifesto.md
-- **Release Process**: https://raw.githubusercontent.com/humanity4ai/project_human/development/docs/release-process.md
-- **Package Release**: https://raw.githubusercontent.com/humanity4ai/project_human/development/docs/package-release.md
+- **Documentation Index**: https://raw.githubusercontent.com/humanity4ai/project_human/main/docs/README.md
+- **Protocol Specification**: https://raw.githubusercontent.com/humanity4ai/project_human/main/docs/protocol.md
+- **Agent Adapter Guide**: https://raw.githubusercontent.com/humanity4ai/project_human/main/docs/agent-adapters.md
+- **Quality Gates**: https://raw.githubusercontent.com/humanity4ai/project_human/main/docs/quality-gates.md
+- **Worked Example**: https://raw.githubusercontent.com/humanity4ai/project_human/main/docs/worked-example.md
+- **Manifesto**: https://raw.githubusercontent.com/humanity4ai/project_human/main/docs/manifesto.md
+- **Release Process**: https://raw.githubusercontent.com/humanity4ai/project_human/main/docs/release-process.md
+- **Package Release**: https://raw.githubusercontent.com/humanity4ai/project_human/main/docs/package-release.md

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,21 +1,20 @@
 # Humanity4AI Skills
 
-This directory contains the 11 launch skill packs for Humanity4AI v1.0. Each skill is a self-contained unit with a machine-readable specification (`SKILL.md`), a YAML configuration (`skill.yaml`), evaluation scenarios, and a scoring rubric.
+This directory contains the 9 launch skill packs for Humanity4AI. Each skill is a self-contained unit with a machine-readable specification (`SKILL.md`), a YAML configuration (`skill.yaml`), evaluation scenarios, and a scoring rubric.
 
 ## Skill Index
 
 | Skill | Category | Description |
 |---|---|---|
+| [`accessibility`](./accessibility/) | `accessibility` | Unified WCAG 2.2 audit — scores pages against all 86 criteria (A/AA/AAA). |
 | [`age-inclusive-design`](./age-inclusive-design/) | `age-inclusion` | Design for users of all ages. |
 | [`cognitive-accessibility`](./cognitive-accessibility/) | `cognitive-support` | Improve content for varied attention, memory, and executive function. |
 | [`conflict-de-escalation`](./conflict-de-escalation/) | `conflict-navigation` | De-escalate tense interactions. |
 | [`cultural-sensitivity`](./cultural-sensitivity/) | `cultural-context` | Design for cultural inclusivity. |
 | [`depression-sensitive-content`](./depression-sensitive-content/) | `emotional-safety` | Audit and rewrite content to reduce stigma and improve emotional safety. |
 | [`empathetic-communication`](./empathetic-communication/) | `communication` | Improve emotional resonance in communication. |
-| [`supportive-conversation`](./supportive-conversation/) | `emotional-safety` | Offer non-clinical, compassionate support language for grief, loss, and emotional distress. |
 | [`neurodiversity-aware-design`](./neurodiversity-aware-design/) | `neurodiversity` | Design for diverse cognitive processing. |
-| [`supportive-conversation`](./supportive-conversation/) | `communication` | Generate supportive responses with safety boundaries. |
-| [`wcag-aaa-accessibility`](./wcag-aaa-accessibility/) | `accessibility` | Audit a webpage or HTML for WCAG 2.2 AAA compliance. |
+| [`supportive-conversation`](./supportive-conversation/) | `emotional-safety` | Offer non-clinical, compassionate support language for grief, loss, and emotional distress. |
 
 ## Skill Structure
 

--- a/skills/accessibility/SKILL.md
+++ b/skills/accessibility/SKILL.md
@@ -42,7 +42,7 @@ Two analysis engines:
 
 Implementation guidance and enterprise patterns (merged from `wcag-aaa-web-design`):
 
-- `references/wcag-aaa-checklist.md` — all 87 WCAG 2.2 criteria with implementation guidance and AAA design implications
+- `references/wcag-aaa-checklist.md` — all 86 WCAG 2.2 criteria with implementation guidance and AAA design implications
 - `references/corporate-design-system.md` — AAA-verified color palette with precomputed contrast ratios, type scale, BEM architecture
 - `references/aria-patterns.md` — ARIA widget patterns (modals, tabs, accordions, focus traps)
 - `references/form-patterns.md` — accessible form design and validation


### PR DESCRIPTION
## Summary

Fixes 15+ stale references across 19 documentation files found by comprehensive audit.

### Critical fixes

- **llms.txt / llms-full.txt**: 66 dead URLs pointing to deleted `development` branch → `main`
- **install.sh**: Node version check threshold `<20` → `<22` (was checking wrong version)
- **docs/INSTALL.md**: 7 stale "11" action/gate counts → "9"/"10"
- **docs/SYSTEM_PROMPT.md**: 11→9 skill rows, removed duplicate + stale `wcag-aaa-accessibility`/`wcag-aa-accessibility` paths
- **docs/README.md**: Removed duplicate supportive-conversation row + 2 stale WCAG paths
- **skills/README.md**: 11→9, removed stale entries
- **CITATION.cff**: Version 0.2.0→1.0.4, 10→9 specifications

### Consistency fixes

- **AGENTS.md**: Removed duplicate F-005 paragraph
- **docs/ROADMAP.md**: Moved HTTP/SSE transport + Vercel to v1.0 (already implemented)
- **skills/accessibility/SKILL.md**: 87→86 WCAG criteria match
- **docs/quality-gates.md, evals/README.md**: Stale `wcag-aa`/`wcag-aaa` references
- **.github/pull_request_template.md**: 11→10 gates
- **docs/protocol.md, docs/REPO_MAP.md, docs/traction-14-day.md, docs/good-first-issues.md, docs/manifesto-coverage-map.md, docs/worked-example.md**: Various stale references

### Verification

No TypeScript changes — CI should pass trivially (pnpm check, evals, tests unchanged).