### PR TITLE
docs: align all documentation with v1.0.6 + promote AGENTS.md to committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ coverage/
 .DS_Store
 Thumbs.db
 reports/
-AGENTS.md
 specs/
 legacy/
 mcp-servers/coverage/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,173 @@
+# AGENTS.md — Agentic Coding Guidelines
+
+---
+
+## CRITICAL: All compute in GitHub Codespaces
+
+**NEVER run compilation, testing, builds, linting, or installs on the local machine.**
+These operations are blocked in opencode.json and must run in a GitHub Codespace.
+
+```bash
+gh cs ssh <name> -- "cd /workspaces/project_human && pnpm check"
+gh cs cp <changed-file> remote:/workspaces/project_human/<path>
+```
+
+Sync files to your codespace after making edits, then run verification there.
+
+---
+
+## Commands (Codespace only)
+
+pnpm monorepo. Two packages: `@humanity4ai/mcp-servers` (publishable) and `@humanity4ai/evals` (private).
+
+```bash
+pnpm check          # tsc --noEmit across all packages
+pnpm start          # MCP server via tsx (stdio transport)
+pnpm test           # vitest run (both packages)
+pnpm test:coverage  # vitest --coverage
+pnpm evals          # skill eval harness (10 checks: 9 skills + contract-consistency)
+pnpm build          # compile mcp-servers → dist/
+```
+
+**Single test / single package:**
+```bash
+pnpm --filter @humanity4ai/mcp-servers test -- --test-name-pattern "H-1"
+pnpm --filter @humanity4ai/mcp-servers test -- src/__tests__/handlers.test.ts
+pnpm --filter @humanity4ai/mcp-servers check
+pnpm --filter @humanity4ai/evals test
+```
+
+**Pre-commit (run in codespace):** `pnpm check && pnpm evals && pnpm test`.
+CI order: `check` → `build` → `EVAL_REPORT=1 pnpm evals` → `test:coverage` (both packages).
+
+---
+
+## Coverage Thresholds
+
+| Package | Stmts | Branch | Funcs | Lines |
+|---------|-------|--------|-------|-------|
+| mcp-servers | 90% | **83%** | 90% | 90% |
+| evals | 78% | 65% | 80% | 78% |
+
+**Excluded from coverage (vitest.config.ts):** `bin.ts`, `accessibility-engine.ts`, `server-factory.ts`.
+`wcag-criteria.ts` included (96% covered by modules.test.ts).
+New conditionals → new tests in `__tests__/modules.test.ts`.
+
+---
+
+## Architecture
+
+### Package layout
+- **`mcp-servers/src/server-factory.ts`** — shared `createServer()` → registers all 9 tools on an `McpServer`. Used by both stdio (`mcp-server.ts`) and HTTP (`api/mcp.ts`) transports.
+- **`mcp-servers/src/mcp-server.ts`** — thin stdio wrapper: imports factory, connects `StdioServerTransport`. Re-exports handlers + `VERSION` for test compatibility.
+- **`mcp-servers/api/mcp.ts`** — Vercel serverless function using `StreamableHTTPServerTransport` in stateless mode. Imports factory + handlers from npm package.
+- **`mcp-servers/src/schemas-data.ts`** — auto-generated at build time: all 18 JSON schemas as inline JS objects. `validate.ts` imports this instead of `readFileSync` — zero file I/O, works in all bundler environments (Vercel, Cloudflare).
+- **`mcp-servers/src/validate.ts`** — input validation against inline `SCHEMA_REGISTRY`. No `node:fs` dependency. Called by `invokeAction` at handler dispatch time.
+- **`mcp-servers/src/handlers.ts`** — 9 private handler functions + `invokeAction(action, input)` dispatcher.
+- **`knowledge-core/taxonomy.ts`** — canonical `CATEGORY_SLUGS` + `ESCALATION_REQUIRED_SKILLS` (typed `const` arrays). `taxonomy.md` is the human-readable reference.
+- **`evals/src/run-evals.ts`** — parses `VALID_CATEGORIES` from `knowledge-core/taxonomy.md` at runtime (no hardcoded duplicate). 10 checks: 9 skills + `contract-consistency`.
+
+### Key facts
+- **MCP server is rule-based** — no LLM calls, no external APIs.
+- **Contracts** in `index.ts` (TypeScript array of `ActionContract`).
+- **Schemas**: `schemas/<skill>.input|output.json` — 18 files (9 skills × 2). Bundled at build time into `schemas-data.ts`.
+- **Shared modules** (import from these, don't duplicate):
+  - `patterns.ts` — 16 pattern categories (shame, urgency, crisis, grief, emotion, etc.)
+  - `crisis-resources.ts` — crisis phone numbers/URLs (988, 741741, 116 123, IASP, findahelpline.com)
+  - `crisis-detection.ts` — `detectCrisisSignals()`, `detectSafetySignals()`
+  - `emotion-detection.ts` — `detectEmotion()` (6 categories)
+  - `accessibility-engine.ts` — 13 scoring functions (86 WCAG 2.2 criteria), optional axe-core integration
+  - `wcag-criteria.ts` — `WCAG_CRITERIA` array (86 entries), `getChecklist(level)`, `criteriaByLevel(level)`
+  - `i18n.ts` — 9 languages, `normalizeLocale()`, `getLocalizedCrisisResources()`
+- **`invokeAction` is async** — returns `Promise<HandlerResult>`. All callers must `await`.
+- **`validateContracts()` called at startup** — `createServer()` in `server-factory.ts` calls it before registering tools. Fail-fast on malformed contracts.
+- **Server startup guard**: `mcp-server.ts` skips auto-start when `NODE_ENV === "test"`.
+- **`mcpName`** in `mcp-servers/package.json`: `io.github.humanity4ai/project-human` — for MCP Registry publishing.
+- **engines.node**: `>=22` across all packages. Node 20 is EOL. CI tests Node 22 exclusively.
+
+### npm package: `@humanity4ai/mcp-servers`
+- Subpath exports: `.`, `./handlers`, `./types`, `./validate`, `./schemas/*`
+- Bin: `mcp-servers` → `./dist/bin.js` (imports `mcp-server.js`; auto-run guard prevents double-start)
+- `prepack` → `pnpm build` (rebuilds dist before publish)
+- Publish: build dist in Codespace → `pnpm pack` → copy tarball locally → `npm publish <tarball> --access public` (local Node 20 can't run prepack; publish tarball directly)
+
+### Vercel deployment
+- Project: `humanity4ai-mcp` on `simon-maks-projects` team
+- Deploy: `vercel_deploy_to_vercel` MCP tool with `api/mcp.ts` + `package.json` + optional `vercel.json`
+- SSO protection disabled via `PATCH /v9/projects/:id` with `{"ssoProtection": null}`
+- Aliases: `humanity4ai-mcp-simon-maks-projects.vercel.app`
+
+---
+
+## Code Conventions
+
+**Handler pattern** (all 9 handlers return this):
+```typescript
+type HandlerResult =
+  | { ok: true; data: InvokeResponse }
+  | { ok: false; error: string };
+```
+`InvokeResponse`: `{ action, output, assumptions, uncertainty, boundaryNotice }`
+
+- Error messages include hints (e.g., "Use tools/list to see available actions")
+- ESM with `.js` extension in relative imports (NodeNext)
+- Zod for contract validation; `validate.ts` for MCP input validation (uses inline `SCHEMA_REGISTRY`)
+- `validate.ts`: rejects empty strings for required fields, validates array item types, enforces minLength/maxLength
+
+---
+
+## Git Workflow
+
+```
+feature/* → main (default branch)
+```
+
+All PRs target `main`. CI on push/PR. Merged branches auto-deleted. `development` branch deleted — do not recreate.
+
+**Branch protection (ruleset `main-protection`):** PR required + `validate (22)`/`CodeQL` checks must pass. Direct pushes to `main` are rejected (409). If CI doesn't auto-trigger on a PR, manually dispatch via `gh workflow run ci.yml --ref <branch>`.
+
+**Auth (repo-local only):** pushes to `https://github.com/humanity4ai/` authenticate as `humanity4ai` via fine-grained PAT in `$HUMANITY4AI_PAT` (`~/.env.opencode`), wired through a URL-scoped credential helper in `.git/config`. For gh CLI admin calls: `GH_TOKEN="$HUMANITY4AI_PAT" gh api ...`.
+
+---
+
+## Pitfalls
+
+### Never hardcode crisis phone numbers
+Import from `crisis-resources.ts`. All crisis numbers live there. Adding one edits exactly one file.
+
+### Coverage threshold is 83% branches
+New if/else/ternary/switch = new tests. `server-factory.ts`, `accessibility-engine.ts`, and `bin.ts` are excluded. Run `pnpm --filter @humanity4ai/mcp-servers test:coverage` before push.
+
+### supportive-conversation category
+Category is `emotional-safety`. Now includes grief support modes (presence, practical, reflection). Enforced in `knowledge-core/taxonomy.md` and `skills/index.yaml`.
+
+### Nine skills, not ten or eleven
+WCAG AAA + AA consolidated into `accessibility` (1 skill). Grief-loss-support removed. No reproduction. `skills/index.yaml` count must be 9.
+
+### Python scripts are in legacy/
+The 112 Python scripts were moved to `legacy/python-scripts/` — the MCP server never called them. All patterns are in `patterns.ts`.
+
+### specs/ is gitignored
+SDD artifacts are local-only. Don't reference them in committed code.
+
+### docs/ is where documentation lives
+ROADMAP, INSTALL, GOVERNANCE, SYSTEM_PROMPT, etc. are in `docs/` (not root).
+
+### Site deploys automatically
+Push to `main` with `site/**` changes triggers GitHub Pages deploy.
+
+### dist/ is committed
+NOT in `.gitignore`. Built `dist/` directory must be committed (needed for npm pack and npx entry point). Run `pnpm build` before release commits.
+**Design decision (F-005 — maintained):** Retained for npx compatibility, reviewable diffs, and fresh checkout guarantees.
+
+### schemas are bundled at build time
+`schemas-data.ts` contains all 18 JSON schemas as inline JS objects. `validate.ts` imports from it — no `readFileSync`, no `node:fs`, no `import.meta.url` path resolution. This means the package works in all bundler environments (Vercel, Cloudflare Workers, etc.) without additional config. When adding a new skill schema, regenerate `schemas-data.ts`.
+
+### CI may not trigger on non-feature/* branches
+If a PR's head branch doesn't match `feature/*`, CI might not auto-trigger. Manually dispatch: `gh workflow run ci.yml --ref <branch>`. Both `validate (22)` and `CodeQL` must pass before merge.
+
+### No grief-loss-support
+Grief support is handled by `supportive_reply` (supportive-conversation skill). Grief-loss-support skill dir, schemas, and contract were removed — do not recreate them.
+
+### Vercel deploy requires inline schemas
+The Vercel function at `api/mcp.ts` calls `invokeAction` from the npm package. Since v1.0.6, schemas are inline — no need to copy schema files to deployment root. Deploy with bare `npm install` (no postinstall tricks, no buildCommand).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,5 +21,5 @@ keywords:
   - skills
   - human-centered AI
 license: MIT
-version: 1.0.5
+version: 1.0.6
 date-released: "2026-07-24"

--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ All 9 skills are now discoverable via `tools/list` and invocable via `tools/call
 
 ---
 
-## Three Ways to Use
+## Four Ways to Use
 
 | Method | Best for | How |
 |--------|----------|-----|
-| **MCP Server** | VS Code, Cursor, Claude Code, Copilot, Manus AI, OpenCode | Start the server, configure your agent's MCP client |
+| **Remote URL** | Zero-setup, any MCP client | Point to `https://humanity4ai-mcp-simon-maks-projects.vercel.app/api/mcp` |
+| **MCP Server** | VS Code, Cursor, Claude Code, Copilot, Manus AI, OpenCode | `npx @humanity4ai/mcp-servers` or clone & start |
 | **LLM Prompting** | ChatGPT, Claude, Gemini (web chat) | Share `llms.txt` or paste `llms-full.txt` into the chat |
 | **Local Files** | Offline CLI tools | Clone the repo, point your tool at the `skills/` directory |
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -57,7 +57,7 @@ pnpm start
 The server will print a startup banner to stderr:
 
 ```
-Humanity4AI MCP Server v1.0.5
+Humanity4AI MCP Server v1.0.6
 Actions: 9 registered
 Transport: stdio (MCP JSON-RPC 2.0)
 Ready
@@ -203,3 +203,25 @@ pnpm evals             # All 10 quality gates pass
 echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | pnpm --filter @humanity4ai/mcp-servers exec tsx src/mcp-server.ts
 # Should return JSON with 9 actions
 ```
+
+## Vercel Deployment (Remote Access)
+
+A public MCP endpoint is deployed at:
+
+```
+https://humanity4ai-mcp-simon-maks-projects.vercel.app/api/mcp
+```
+
+Users connect with zero setup — just configure the URL in their MCP client:
+
+```json
+{
+  "mcpServers": {
+    "humanity4ai": {
+      "url": "https://humanity4ai-mcp-simon-maks-projects.vercel.app/api/mcp"
+    }
+  }
+}
+```
+
+To deploy your own instance: connect the repo to Vercel, set **Root Directory** to `mcp-servers/`. The function at `api/mcp.ts` uses `StreamableHTTPServerTransport` in stateless mode with schemas bundled as inline JS data — no file I/O, no build tricks needed. SSO protection must be disabled for public MCP access (`PATCH /v9/projects/:id` with `{"ssoProtection": null}`).

--- a/docs/manifesto-coverage-map.md
+++ b/docs/manifesto-coverage-map.md
@@ -82,4 +82,4 @@ Each of the 5 Humanity4AI core principles mapped to implementation artifacts.
 **No uncovered principles. All 5 principles have at least 7 traceable artifacts across code, tests, docs, and CI.**
 
 ---
-Generated: 2026-07-24 | v1.0.4
+Generated: 2026-07-24 | v1.0.6

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -29,7 +29,7 @@ Before calling any tools, clients must send an `initialize` request:
 Response:
 
 ```json
-{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"humanity4ai-mcp",  "version":"1.0.4"}}}
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"humanity4ai-mcp",  "version":"1.0.6"}}}
 ```
 
 ---

--- a/docs/worked-example.md
+++ b/docs/worked-example.md
@@ -29,7 +29,7 @@ pnpm start
 You will see on stderr:
 
 ```
-Humanity4AI MCP Server v1.0.4 (JSON-RPC 2.0)
+Humanity4AI MCP Server v1.0.6 (JSON-RPC 2.0)
 Tools: 9 registered
 Transport: stdio (MCP SDK)
 Ready — waiting for MCP client connections

--- a/mcp-servers/README.md
+++ b/mcp-servers/README.md
@@ -27,7 +27,11 @@ pnpm --filter @humanity4ai/mcp-servers start
 The server starts on **stdio** using the official MCP SDK JSON-RPC 2.0 protocol.
 All 9 humanity skills are registered as MCP tools and discoverable via `tools/list`.
 
+A remote endpoint is also available at `https://humanity4ai-mcp-simon-maks-projects.vercel.app/api/mcp` using Streamable HTTP transport — no clone needed.
+
 ### 3. Configure your MCP client
+
+**Local (stdio):**
 
 Add to your MCP client configuration (e.g. `claude_desktop_config.json`, `.cursor/mcp.json`, `opencode.json`):
 
@@ -56,6 +60,18 @@ Or use `npx` once published to npm (no local clone needed):
 }
 ```
 
+**Remote (Streamable HTTP):**
+
+```json
+{
+  "mcpServers": {
+    "humanity4ai": {
+      "url": "https://humanity4ai-mcp-simon-maks-projects.vercel.app/api/mcp"
+    }
+  }
+}
+```
+
 ---
 
 ## Available Tools (9 skills)
@@ -76,7 +92,10 @@ Or use `npx` once published to npm (no local clone needed):
 
 ## Protocol
 
-The server uses the official `@modelcontextprotocol/sdk` and communicates via **JSON-RPC 2.0 over stdio**.
+The server uses the official `@modelcontextprotocol/sdk` and communicates via **JSON-RPC 2.0** over two transports:
+
+- **stdio** — local process (clone & run, npx, Docker)
+- **Streamable HTTP** — remote deployment (Vercel, stateless mode)
 
 **Tool discovery:**
 ```json
@@ -109,10 +128,10 @@ Every tool response includes a `boundaryNotice` field. Always surface this to us
 
 ## Package Use
 
-Install from npm once published:
-
 ```bash
 pnpm add @humanity4ai/mcp-servers
+# or
+npm install @humanity4ai/mcp-servers
 ```
 
 Import contracts programmatically:
@@ -142,9 +161,9 @@ The `examples/` directory contains one complete request/response pair per action
 
 ---
 
-## v1.1+ Roadmap
+## Roadmap
 
-- HTTP/SSE transport for remote MCP server deployments
-- Auth policies and rate controls
+- Auth policies and rate controls for remote deployments
 - Telemetry and evaluation hooks
 - Rich scenario scoring beyond structural checks
+- MCP Registry listing (mcp-publisher)


### PR DESCRIPTION
## Summary

Final documentation alignment sweep — all remaining stale references updated to v1.0.6, Vercel endpoint documented everywhere, and AGENTS.md promoted from gitignored to committed reference.

### Documents updated (8 files)

| File | Change |
|------|--------|
| `README.md` | Added "Remote URL" as 4th usage method (zero-setup Vercel endpoint) |
| `mcp-servers/README.md` | Remote URL config, Streamable HTTP transport, updated roadmap |
| `docs/INSTALL.md` | Vercel deployment section with public endpoint URL |
| `AGENTS.md` | Complete rewrite: server-factory.ts, schemas-data.ts, inline schemas, coverage excludes, engines >=22, mcpName, Vercel deploy, CI quirks |
| `.gitignore` | Removed AGENTS.md exclusion (now a committed reference) |
| `CITATION.cff` | 1.0.5 → 1.0.6 |
| `docs/protocol.md` | 1.0.4 → 1.0.6 |
| `docs/manifesto-coverage-map.md` | 1.0.4 → 1.0.6 |
| `docs/worked-example.md` | 1.0.4 → 1.0.6 |

### Verification

No TypeScript changes — doc-only PR.