### PR TITLE
docs: update all MCP URLs to humanity4ai.ascent.partners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,10 +92,10 @@ New conditionals → new tests in `__tests__/modules.test.ts`.
 - Publish: build dist in Codespace → `pnpm pack` → copy tarball locally → `npm publish <tarball> --access public` (local Node 20 can't run prepack; publish tarball directly)
 
 ### Vercel deployment
+- Domain: `https://humanity4ai.ascent.partners/api/mcp`
 - Project: `humanity4ai-mcp` on `simon-maks-projects` team
-- Deploy: `vercel_deploy_to_vercel` MCP tool with `api/mcp.ts` + `package.json` + optional `vercel.json`
+- Deploy: `vercel_deploy_to_vercel` MCP tool with `api/mcp.ts` + `package.json`
 - SSO protection disabled via `PATCH /v9/projects/:id` with `{"ssoProtection": null}`
-- Aliases: `humanity4ai-mcp-simon-maks-projects.vercel.app`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ All 9 skills are now discoverable via `tools/list` and invocable via `tools/call
 
 | Method | Best for | How |
 |--------|----------|-----|
-| **Remote URL** | Zero-setup, any MCP client | Point to `https://humanity4ai-mcp-simon-maks-projects.vercel.app/api/mcp` |
+| **Remote URL** | Zero-setup, any MCP client | Point to `https://humanity4ai.ascent.partners/api/mcp` |
 | **MCP Server** | VS Code, Cursor, Claude Code, Copilot, Manus AI, OpenCode | `npx @humanity4ai/mcp-servers` or clone & start |
 | **LLM Prompting** | ChatGPT, Claude, Gemini (web chat) | Share `llms.txt` or paste `llms-full.txt` into the chat |
 | **Local Files** | Offline CLI tools | Clone the repo, point your tool at the `skills/` directory |

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -209,7 +209,7 @@ echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | pnpm --filte
 A public MCP endpoint is deployed at:
 
 ```
-https://humanity4ai-mcp-simon-maks-projects.vercel.app/api/mcp
+https://humanity4ai.ascent.partners/api/mcp
 ```
 
 Users connect with zero setup — just configure the URL in their MCP client:
@@ -218,7 +218,7 @@ Users connect with zero setup — just configure the URL in their MCP client:
 {
   "mcpServers": {
     "humanity4ai": {
-      "url": "https://humanity4ai-mcp-simon-maks-projects.vercel.app/api/mcp"
+      "url": "https://humanity4ai.ascent.partners/api/mcp"
     }
   }
 }

--- a/mcp-servers/README.md
+++ b/mcp-servers/README.md
@@ -27,7 +27,7 @@ pnpm --filter @humanity4ai/mcp-servers start
 The server starts on **stdio** using the official MCP SDK JSON-RPC 2.0 protocol.
 All 9 humanity skills are registered as MCP tools and discoverable via `tools/list`.
 
-A remote endpoint is also available at `https://humanity4ai-mcp-simon-maks-projects.vercel.app/api/mcp` using Streamable HTTP transport — no clone needed.
+A remote endpoint is also available at `https://humanity4ai.ascent.partners/api/mcp` using Streamable HTTP transport — no clone needed.
 
 ### 3. Configure your MCP client
 
@@ -66,7 +66,7 @@ Or use `npx` once published to npm (no local clone needed):
 {
   "mcpServers": {
     "humanity4ai": {
-      "url": "https://humanity4ai-mcp-simon-maks-projects.vercel.app/api/mcp"
+      "url": "https://humanity4ai.ascent.partners/api/mcp"
     }
   }
 }


### PR DESCRIPTION
Doc-only: replaces all Vercel deployment URLs with the custom domain.

## Summary
- `README.md` — Remote URL updated
- `docs/INSTALL.md` — endpoint + config snippet updated  
- `mcp-servers/README.md` — endpoint + config snippet updated
- `AGENTS.md` — domain added

## Deployed
- `https://humanity4ai.ascent.partners/api/mcp` — GET returns a landing page, POST is the MCP endpoint
- All 9 tools working, no Accept header required