### PR TITLE
docs: best-practice gaps — badges, architecture diagram, npm logo, social preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![npm](https://img.shields.io/npm/v/@humanity4ai/mcp-servers?color=0f766e)](https://www.npmjs.com/package/@humanity4ai/mcp-servers)
 [![License: MIT](https://img.shields.io/badge/license-MIT-0f766e)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/humanity4ai/project_human)](https://github.com/humanity4ai/project_human/releases)
-[![Contributors](https://img.shields.io/github/contributors/humanity4ai/project_human)](https://github.com/humanity4ai/project_human/graphs/contributors)
+[![Works with](https://img.shields.io/badge/works_with-VS%20Code%20%7C%20Cursor%20%7C%20Claude%20Code-0f766e)](https://github.com/humanity4ai/project_human?tab=readme-ov-file#quick-start)
 [![CodeQL](https://github.com/humanity4ai/project_human/actions/workflows/codeql.yml/badge.svg)](https://github.com/humanity4ai/project_human/actions/workflows/codeql.yml)
 
 ---
@@ -72,6 +72,22 @@ All 9 skills are discoverable via `tools/list` and invocable via `tools/call`.
 **Prerequisites (for local only):** Node.js >= 22, pnpm >= 10 | Windows, macOS, Linux, Android, iOS
 
 ---
+
+## Architecture
+
+```mermaid
+graph TD
+    A[MCP Client<br/>VS Code / Cursor / Claude Code] -->|stdio| B[mcp-server.ts]
+    A -->|HTTP POST| C[Vercel<br/>humanity4ai.ascent.partners]
+    B --> D[server-factory.ts<br/>createServer]
+    C -->|api/mcp.ts| D
+    D --> E[9 Tool Registrations]
+    E --> F[handlers.ts<br/>invokeAction]
+    F --> G[validate.ts<br/>SCHEMA_REGISTRY]
+    G --> H[schemas-data.ts<br/>18 inline schemas]
+    F --> I[9 Handler Functions<br/>rule-based, zero LLM calls]
+    I --> J[crisis-resources<br/>patterns<br/>i18n<br/>wcag-criteria]
+```
 
 ## Four Ways to Use
 

--- a/mcp-servers/README.md
+++ b/mcp-servers/README.md
@@ -1,5 +1,7 @@
 # @humanity4ai/mcp-servers
 
+![Humanity4AI](https://raw.githubusercontent.com/humanity4ai/project_human/main/site/assets/favicon.svg)
+
 MCP action contracts and server runtime for Humanity4AI skills.
 
 All 9 humanity skills are exposed as standard MCP tools using the official `@modelcontextprotocol/sdk` JSON-RPC 2.0 protocol, natively compatible with Claude Code, Copilot, Manus AI, OpenCode, LangChain, and any other MCP SDK client.

--- a/site/index.html
+++ b/site/index.html
@@ -16,15 +16,15 @@
     <meta property="og:description" content="9 humanity skills for AI agents — crisis detection, WCAG audits, empathy, cultural sensitivity, and more. MCP + npm." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://humanity4ai.github.io/project_human/" />
-    <meta property="og:image" content="https://humanity4ai.github.io/project_human/assets/hero-architecture.svg" />
-    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image" content="https://humanity4ai.github.io/project_human/assets/hero-preview.png" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Humanity4AI — 9 Humanity Skills for AI Agents" />
     <meta name="twitter:description" content="9 humanity skills for AI agents — crisis detection, WCAG audits, empathy, cultural sensitivity, and more." />
-    <meta name="twitter:image" content="https://humanity4ai.github.io/project_human/assets/hero-architecture.svg" />
+    <meta name="twitter:image" content="https://humanity4ai.github.io/project_human/assets/hero-preview.png" />
     <!-- Canonical -->
     <link rel="canonical" href="https://humanity4ai.github.io/project_human/" />
     <!-- Favicon -->


### PR DESCRIPTION
## Summary

Closes remaining gaps from best-practice comparison against fastmcp, Claude Code, MCP Inspector:

### Implemented
- **Platform badge** (shields.io): "Works with VS Code | Cursor | Claude Code"
- **Mermaid architecture diagram** in README: visual flow from Client → Factory → Handlers → Schemas
- **npm logo**: `mcp-servers/README.md` now renders with project logo on npmjs.com
- **Social preview fix**: og:image switched from SVG → PNG (better Twitter/X/Discord rendering)

### Deployed separately
- Root landing page at `humanity4ai.ascent.partners/`
- GET handler at `/api/mcp` returns skills page
- npx-first quick-start in README

### Remaining (manual or separate)
- Terminal demo GIF (vhs + GitHub Action — needs .tape file creation)
- Vercel OG image endpoint (separate edge function)
- GitHub Discussions welcome post (one-time UI action)