### PR TITLE
fix: install ffmpeg before VHS action

### DIFF
--- a/.github/workflows/vhs.yml
+++ b/.github/workflows/vhs.yml
@@ -21,6 +21,7 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: sudo apt-get update -qq && sudo apt-get install -y -qq ffmpeg
       - uses: charmbracelet/vhs-action@v2
         with:
           path: 'vhs.tape'


### PR DESCRIPTION
Adds ffmpeg install before VHS action. Previous runs failed because ffmpeg wasn't available.