### PR TITLE
fix: use direct VHS CLI instead of vhs-action

### DIFF
--- a/.github/workflows/vhs.yml
+++ b/.github/workflows/vhs.yml
@@ -22,10 +22,8 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: sudo apt-get update -qq && sudo apt-get install -y -qq ffmpeg
-      - uses: charmbracelet/vhs-action@v2
-        with:
-          path: 'vhs.tape'
-          install: false
+      - run: go install github.com/charmbracelet/vhs@latest
+      - run: ~/go/bin/vhs < vhs.tape
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: 'chore: update demo GIF'


### PR DESCRIPTION
Switch from broken vhs-action to direct VHS CLI via go install